### PR TITLE
Make special script for debugging C Preprocessor issues.

### DIFF
--- a/cmake/preprocess.cmake
+++ b/cmake/preprocess.cmake
@@ -1,0 +1,9 @@
+execute_process(
+  COMMAND "${compiler}" -c -EP -nologo -I "${source_dir}" -Tc "${source_dir}/${file}.def"
+  OUTPUT_FILE "${out_dir}/${file}.i"
+  RESULT_VARIABLE exit_status
+)
+
+if(NOT "${exit_status}" STREQUAL "0")
+  message(FATAL_ERROR "C Preprocessor failed (${exit_status}): '${output_string}'")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,8 +12,14 @@ set(defs
 
 macro(c_preprocess file)
   add_custom_command(
-    OUTPUT "${file}.i"
-    COMMAND "${CMAKE_C_COMPILER}" -c -EP -I "${CMAKE_CURRENT_SOURCE_DIR}" -Tc "${CMAKE_CURRENT_SOURCE_DIR}/${file}.def" > "${CMAKE_CURRENT_BINARY_DIR}/${file}.i"
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${file}.i"
+    COMMAND ${CMAKE_COMMAND}
+    ARGS
+      -Dcompiler=${CMAKE_C_COMPILER}
+      -Dsource_dir=${CMAKE_CURRENT_SOURCE_DIR}
+      -Dout_dir=${CMAKE_CURRENT_BINARY_DIR}
+      -Dfile=${file}
+      -P "${PROJECT_SOURCE_DIR}/cmake/preprocess.cmake"
     MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/${file}.def"
   )
 endmacro()
@@ -21,7 +27,7 @@ endmacro()
 foreach(defFile ${defs})
   string(TOLOWER "${defFile}" defFile)
   string(REPLACE ".def" "" file "${defFile}")
-  c_preprocess(${file})  
+  c_preprocess(${file})
 endforeach()
 
 # Run RCDEF


### PR DESCRIPTION
@chipbarnaby this doesn't exactly solve our problem, but it helps debug the problems in the future. I suspect there was something strange happening with CMake where it wasn't checking to make sure dependencies existed and would skip the command entirely if there weren't any existing dependencies.