### PR TITLE
Added water heater wsTUse re-heat (whxBU) end use assignment

### DIFF
--- a/doc/src/records/dhwheater.md
+++ b/doc/src/records/dhwheater.md
@@ -321,6 +321,14 @@ Name of METER object, if any, by which DHWHEATER electrical energy use is record
   ----------- ------------------- --------------------------- -------------- -----------------
               *name of a METER*   *Parent DHWSYS wsElecMtr*   No             constant
 
+**whxBUEndUse=*choice***
+
+Specifies the whElecMtr end use, if any, to which extra backup energy is accumulated. In some water heater types, extra backup energy is modeled to maintain output temperature at wsTUse.  This energy is included in end use dhwBU.  whxBUEndUse allows separate reporting of extra backup energy for testing purposes.
+
+**Units**   **Legal Range**     **Default**                 **Required**   **Variability**
+----------- ------------------- --------------------------- -------------- -----------------
+            *end use code*            (no accumulation)             No             constant
+
 **whFuelMtr =*mtrName***
 
 Name of METER object, if any, by which DHWHEATER fuel energy use is recorded (under end use DHW).

--- a/src/CNCULT.CPP
+++ b/src/CNCULT.CPP
@@ -1802,6 +1802,7 @@ CULT( "whPilotPwr",  DAT,   DHWHEATER_PILOTPWR,0,     0, VHRLY,  TYFL,  0,      
 CULT( "whParElec",   DAT,   DHWHEATER_PARELEC, 0,     0, VHRLY,  TYFL,  0,      0.f,    N, N),
 CULT( "whElecMtr",   DAT,   DHWHEATER_ELECMTRI,0,     0, VEOI,	 TYREF, &MtriB, N,      N, N),
 CULT( "whFuelMtr",   DAT,   DHWHEATER_FUELMTRI,0,     0, VEOI,	 TYREF, &MtriB, N,      N,   N),
+CULT( "whxBUEndUse", DAT,	DHWHEATER_XBUENDUSE,0,    0, VEOI,   TYCH,  0,      0,	    N,   N),
 CULT( "endDHWHEATER",ENDER, 0,                 0,     0, 0,      0,     0,      0.f,    N,   N),
 CULT()
 };	// dhwHeaterT

--- a/src/CNRECS.DEF
+++ b/src/CNRECS.DEF
@@ -3513,7 +3513,7 @@ RECORD DHWHEATER "DHWHeater" *RAT	// input / runtime DHW heater
   *declare "MTR* wh_pMtrElec; MTR* wh_pMtrFuel; /*MTR* wh_pMtrPrim;*/"
 							// runtime pointers to meters, NULL if not accum'ing
   *i ENDUSECH wh_xBUEndUse;	// wh_elecMtri end use for separate accounting of wh_HPWHxBU
-							//   default = none (note wh_HPWHxBU is always included in end use dhwBU)
+							//   default = none (include wh_HPWHxBU in end use dhwBU)
 
 							// energy inputs for current hour, Btu
 							// for single WH (wh_mult / ws_mult not applied)

--- a/src/DHWCalc.cpp
+++ b/src/DHWCalc.cpp
@@ -546,20 +546,6 @@ RC DHWSYS::ws_DoHour(		// hourly calcs
 	VSet( ws_whDrawDurF, WHDRAWFDIM, -1.f);
 #endif
 
-#if 0
-	// temperature-dependent end uses
-	VSet( ws_whDrawDurF, WHDRAWFDIM, 1.f);
-	float whDrawF = ws_WF * max( 0.f, ws_DLM - ws_SSF);
-	ws_whDrawVolF[ 0]
-		= ws_whDrawVolF[ C_DHWEUCH_SHOWER]
-		= ws_whDrawVolF[ C_DHWEUCH_BATH] = whDrawF;
-	// temperature independent end uses
-	float whDrawFTempInd = 1.f - ws_SSF;
-	ws_whDrawVolF[ C_DHWEUCH_CWASHR]
-		= ws_whDrawVolF[ C_DHWEUCH_DWASHR]
-		= ws_whDrawVolF[ C_DHWEUCH_FAUCET]
-		= whDrawFTempInd;
-#else
 	// temperature-dependent end uses
 	float whDrawF = ws_WF * max( 0.f, ws_DLM - ws_SSF);
 	ws_whDrawVolF[ 0]
@@ -571,8 +557,8 @@ RC DHWSYS::ws_DoHour(		// hourly calcs
 		= ws_whDrawVolF[ C_DHWEUCH_DWASHR]
 		= ws_whDrawVolF[ C_DHWEUCH_FAUCET]
 		= whDrawFTempInd;
-	VSet( ws_whDrawDurF, WHDRAWFDIM, 1.f);
-#endif
+	VSet( ws_whDrawDurF, WHDRAWFDIM, 1.f);	// TODO: derive duration factors
+
 
 #if defined( _DEBUG)
 	if (VMin( ws_whDrawVolF, WHDRAWFDIM) < 0.f
@@ -1786,22 +1772,9 @@ RC DHWHEATER::wh_HPWHDoSubhr(		// HPWH subhour
 	wh_totOut += KWH_TO_BTU( qHW) + wh_HPWHxBU;
 
 	// energy use accounting, Btu (electricity only, assume no fuel)
-#if 1
 	wh_AccumElec( mult,
 		wh_HPWHUse[ 1] * BtuperkWh + wh_parElec * Top.subhrDur * BtuperWh,
 	    wh_HPWHUse[ 0] * BtuperkWh);
-#else
-	double inElec   = wh_HPWHUse[ 1] * BtuperkWh + wh_parElec * Top.subhrDur * BtuperWh,
-	double inElecBU = wh_HPWHUse[ 0] * BtuperkWh + wh_HPWHxBU;
-	wh_inElec += inElec;		// hour total
-	wh_inElecBU += inElecBU;
-	if (wh_pMtrElec)
-	{	wh_pMtrElec->H.dhw   += mult * inElec;
-		wh_pMtrElec->H.dhwBU += mult * inElecBU;
-		if (wh_xBUEndUse)
-			wh_pMtrElec->H.mtr_Accum( wh_xBUEndUse, mult*wh_HPWHxBU);
-	}
-#endif
 	return rc;
 }		// DHWHEATER::wh_HPWHDoSubhr
 //-----------------------------------------------------------------------------
@@ -1981,22 +1954,9 @@ x				nColdStarts += min( 1., offMins / 30.);
 	if (wh_pMtrFuel)
 		wh_pMtrFuel->H.dhw += mult * inFuel;
 
-#if 1
 	wh_AccumElec( mult,
 		rcovElec /*startElec*/ + (stbyElec + wh_parElec * Top.subhrDur) * BtuperWh,
 		0.);	// wh_HPWHxBU is only backup
-#else
-	double inElec   = rcovElec /*startElec*/ + (stbyElec + wh_parElec * Top.subhrDur) * BtuperWh;
-	double inElecBU = wh_HPWHxBU;
-	wh_inElec += inElec;		// hour total
-	wh_inElecBU += inElecBU;
-	if (wh_pMtrElec)
-	{	wh_pMtrElec->H.dhw   += mult * inElec;
-		wh_pMtrElec->H.dhwBU += mult * inElecBU;
-		if (wh_xBUEndUse)
-			wh_pMtrElec->H.mtr_Accum( wh_xBUEndUse, mult*wh_HPWHxBU);
-	}
-#endif
 
 	return rc;
 }			// DHWHEATER::whInstUEFDoSubhr


### PR DESCRIPTION
Allow user specification of end use for accounting of virtual DHW resistance heater energy.  Default end use is dhwBU, so change is backward compatible.  With additional into, "real" backup (e.g. HPWH resistance heat) can be distinguished from energy used to maintain wsTUse.

Also some incomplete / harmless groundwork for volume vs duration draw modeling.