### PR TITLE
Add ZNRES unMetHDH and unMetCDH = unmet degree hours

### DIFF
--- a/src/CNGUTS.CPP
+++ b/src/CNGUTS.CPP
@@ -1513,8 +1513,8 @@ LOCAL void FC NEAR doIvlAccum()
 				  Top.isEndHour );			//   non-0 if last call of hour: compute averages
 		if (Top.isEndHour)
 		{	// hour has unmet if more than 0 subhours unmet
-			resp->curr.H.nHrUnMetH = resp->curr.H.nShUnMetH != 0;
-			resp->curr.H.nHrUnMetC = resp->curr.H.nShUnMetC != 0;
+			resp->curr.H.nHrUnMetH = resp->curr.H.unMetHDH != 0.f;
+			resp->curr.H.nHrUnMetC = resp->curr.H.unMetCDH != 0.f;
 		}
 #ifdef SHSZ	// if keeping sum-of-subhours results. cnguts.h. untested. undef 6-92 for speed, flexibility.
 *     if (resp->ss < ZnresB.n)							// except for last (sum-of-zones) record

--- a/src/CNLOADS.CPP
+++ b/src/CNLOADS.CPP
@@ -369,7 +369,7 @@ x	zn_hcFrc = Top.tp_hConvF * i.zn_hcFrcF * pow( max( zn_hcAirXls, 0.f), 0.8f);
 	if (!nMd)				// if zone has no modes (eg startup with no terminals)
 		spCf++;				// tell ztuCompute to build zone mode sequence
 
-	zn_unMetC = zn_unMetH = 0;		// clear unmet load flags
+	zn_unMetCDH = zn_unMetHDH = 0.f;	// unmet temp diffs
 
 	// initialize DHW heat transfer totals
 	//   TODO: could be done in DHW code iff needed
@@ -1086,7 +1086,7 @@ x						printf( "1B\n");
 				{	zn_qsHvac = qcCap;
 					tz = zn_TAirCR( zn_qsHvac*zn_fConv, 0., zn_qsHvac*(1.f-zn_fConv));
 					if (Top.isEndHour)
-						zn_unMetC++;
+						zn_unMetCDH = tz - i.znTC;		// temp excursion above setpoint
 				}
 				// else capacity sufficient
 			}
@@ -1101,7 +1101,7 @@ x						printf( "1B\n");
 					zn_qsHvac = qhCap;
 					tz = zn_TAirCR( zn_qsHvac*zn_fConv, 0., zn_qsHvac*(1.f-zn_fConv));
 					if (Top.isEndHour)
-						zn_unMetH++;
+						zn_unMetHDH = tz - i.znTH;	// temp excursion below setpoint (< 0)
 				}
 				// else capacity sufficient
 			}
@@ -1185,7 +1185,7 @@ RC ZNR::zn_CondixCR2()		// zone conditions, part 2
 		{	if (zn_hcMode == RSYS::rsmHEAT)
 			{	if (tz < zn_tzsp-.001)
 				{	if (Top.isEndHour)
-						zn_unMetH++;		// give system whole hour to hold temp
+						zn_unMetHDH = tz - zn_tzsp;		// hour end temp excursion below set point
 #if 0 && defined( _DEBUG)
 					if (zn_rsFSize > .9999)
 						// air request received: temp should hold
@@ -1200,7 +1200,7 @@ RC ZNR::zn_CondixCR2()		// zone conditions, part 2
 			else if (zn_hcMode == RSYS::rsmCOOL)
 			{	if (tz > zn_tzsp+.001)
 				{	if (Top.isEndHour)
-						zn_unMetC++;		// give system whole hour to hold temp
+						zn_unMetCDH = tz - zn_tzsp;		// hour end temp excursion above set point
 #if 0 && defined( _DEBUG)
 					if (zn_rsFSize > .9999)
 						// air request received: temp should hold

--- a/src/CNRECS.DEF
+++ b/src/CNRECS.DEF
@@ -2365,9 +2365,9 @@ RECORD ZNR "zone" *RAT	// zone runtime info RAT.  Set mainly from separate ZNI
 	*s *e SI zn_hcMode			// heating / cooling mode required per set point (rsmHEAT, rsmCOOL, )
 								//   (may not match RSYS.rs_mode due to e.g. RSYS availability or
 								//    conflicting zone requests)
-								// flag ument heating/cooling requirements (zn_tzsp not held)
-	*s *e INT zn_unMetH			//   nz iff current step heating load not met
-	*s *e INT zn_unMetC			//   nz iff currend step cooling load not met
+								// flag unmet heating/cooling requirements (zn_tzsp not held)
+	*s *e FLOAT zn_unMetHDH		//   tz - znTH at end of hour, deg-hr
+	*s *e FLOAT zn_unMetCDH		//   tz - znTC at end of hour, deg-hr
 	
 								// HVAC convective delivery fraction (TODO: now all 1, 6-2012)
 	*s FLOAT zn_fConvH			//    heating
@@ -2521,8 +2521,6 @@ RECORD ZNRES_IVL_SUB "zone interval results sub" *SUBSTRUCT	// zone interval res
     SI nHrCeilFan	//    ditto ceiling fan operation; last "# of hours"
 //LIs. code in cnguts.h and .cpp assumes LI members together, first is nIter, last is nSubhrLX.
     LI nIter		// # of iterations
-    LI nShUnMetH	// # of substeps in this interval with unmet heating load
-    LI nShUnMetC	//   ditto cooling
     LI nHrUnMetH	// # of hours in this intervals having *any* unmet heating subhours
     LI nHrUnMetC	//   ditto heating
     LI nShVentH		// # of substeps int this interval when ventilation caused heating
@@ -2561,13 +2559,13 @@ RECORD ZNRES_IVL_SUB "zone interval results sub" *SUBSTRUCT	// zone interval res
     float qlBal  	// latent balance similarly.  Consider removing Bals after development.
     float qlX		// latent gain rejected to prevent zone supersaturation === heat of condensation. 
 					//   - added to next subr sens gain. Btu.
-    // following are accessible only via binary results files generated for NREL design tool (ET or E10),
-    // or probes & custom report, as of 9-94. CSE accumulates to H-D-M-Y.
-     float qcMech	// zone accumulated cooling (negative) ...
-     float qhMech	// ... and heating (positive) mechanical heat gains. Latent & sensible combined. 10-93.
-     float qvMech	// ... mechanical (OAV) vent (negative)
-     float litDmd	// zone lighting demand and Energy Use, ...
-     float litEu   	// ... from GAINs, in addition to posting Eu to meter, re daylighting for NREL. 9-94.
+    float unMetHDH	// zone end-of-hour air temp excursion below heating set point, deg-hr (<=0)
+	float unMetCDH	// zone end-of-hour air temp excursion above cooling set point, deg-hr (>=0)
+    float qcMech	// zone accumulated cooling (negative) ...
+    float qhMech	// ... and heating (positive) mechanical heat gains. Latent & sensible combined. 10-93.
+    float qvMech	// ... mechanical (OAV) vent (negative)
+    float litDmd	// zone lighting demand and Energy Use, ...
+    float litEu   	// ... from GAINs, in addition to posting Eu to meter, re daylighting for NREL. 9-94.
 *END		// ZNRES_IVL_SUB
 //=============================================================================
 RECORD ZNRES_SUB "zone results sub" *SUBSTRUCT	

--- a/src/CNZTU.CPP
+++ b/src/CNZTU.CPP
@@ -1046,8 +1046,8 @@ x	// 6-10-92 is above right 1) considering w not computed in a/b form (see znW);
 	zrs->nSubhrLX = (zrs->qlX != 0.f);			// 1 if non-0, 0 if 0: accumulates to # subhrs with condensation.
 
 // subhour results: unmet load (meaningful for ConvRad only 10-2012)
-	zrs->nShUnMetH = zn_unMetH != 0;
-	zrs->nShUnMetC = zn_unMetC != 0;
+	zrs->unMetHDH = zn_unMetHDH;
+	zrs->unMetCDH = zn_unMetCDH;
 
 #if 0 // no, not reporting condensation in autosize (wd need to rerun all days) 5-97
 x// excess latent gain... accumulate to a zone member for reporting during autoSizing, when ZNRES accumulation isn't done


### PR DESCRIPTION
Tracks magnitude of failure to hold heating and cooling set points.