### PR TITLE
Update build error code

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v1
       - name: Build
         shell: cmd
-        run: build.bat no-pause
+        run: build.bat
       - name: Upload executable artifiact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v1
       - name: Build
         shell: cmd
-        run: build.bat no-pause
+        run: build.bat
       - name: Upload executable to release assets
         uses: AButler/upload-release-assets@v2.0
         with:

--- a/build.bat
+++ b/build.bat
@@ -1,6 +1,17 @@
 @echo off
+if "%parent%"=="" set parent=%~0
+if "%console_mode%"=="" (set console_mode=1& for %%x in (%cmdcmdline%) do if /i "%%~x"=="/c" set console_mode=0)
+
 cmake -P cmake/configure.cmake
-cmake -P cmake/build.cmake
-IF "%1"=="" (
-  PAUSE
+if %errorlevel% neq 0 (
+  if "%parent%"=="%~0" ( if "%console_mode%"=="0" pause )
+  exit /B %errorlevel%
 )
+
+cmake -P cmake/build.cmake
+if %errorlevel% neq 0 (
+  if "%parent%"=="%~0" ( if "%console_mode%"=="0" pause )
+  exit /B %errorlevel%
+)
+
+if "%parent%"=="%~0" ( if "%console_mode%"=="0" pause )

--- a/cmake/BuildFlags.cmake
+++ b/cmake/BuildFlags.cmake
@@ -8,7 +8,7 @@ if (MSVC AND NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel"))
   #================#
   # Compiler flags #
   #================#
-  message(FATAL_ERROR "Testing error code")
+
   set(CompileCommon
     /DWIN32     #*
   # /D_WINDOWS  #*

--- a/cmake/BuildFlags.cmake
+++ b/cmake/BuildFlags.cmake
@@ -8,7 +8,7 @@ if (MSVC AND NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel"))
   #================#
   # Compiler flags #
   #================#
-
+  message(FATAL_ERROR "Testing error code")
   set(CompileCommon
     /DWIN32     #*
   # /D_WINDOWS  #*

--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -8,5 +8,5 @@ execute_process(COMMAND ${CMAKE_COMMAND}
 if (${success} MATCHES "0")
   message("Build Successful!")
 else()
-  message("Build failed.")
+  message(FATAL_ERROR "Build failed.")
 endif()

--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -7,6 +7,5 @@ execute_process(COMMAND ${CMAKE_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR} -T v142 -A 
   RESULT_VARIABLE success
 )
 if (NOT ${success} MATCHES "0")
-  message("Generation step failed.")
-  return()
+  message(FATAL_ERROR "Generation step failed.")
 endif()


### PR DESCRIPTION
This pull request exits the batch script if there is an error in either config.cmake or build.cmake steps. It also prevents from closing cmd if ran by double click or straight from the command line.

It also eliminates the need for the `no-pause` command on the CI. See Build and Test #200.