### PR TITLE
Fix CI release deployment of documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         run: 'cinst -y pandoc --version=1.17.2 --ia=ALLUSERS=1'
         shell: bash
       - name: Add pandoc to path
-        run: echo "C:\Program Files (x86)\Pandoc" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        run: echo "C:\Program Files (x86)\Pandoc" >> $GITHUB_PATH
       - name: Add MSVC developer commands to PATH
         uses: ilammy/msvc-dev-cmd@v1
       - name: Build docs


### PR DESCRIPTION
Not much to review here. Just fixing the "add to path" command on the CI now that we've moved the default shell to bash.

I've tested by making a [draft release](https://github.com/cse-sim/cse/releases/tag/v0.900.1) that we can make official or delete.