### PR TITLE
Fix/csv table with literal commas

### DIFF
--- a/doc/test/table_test.rb
+++ b/doc/test/table_test.rb
@@ -70,4 +70,31 @@ END
     actual = Template::RenderWithErb.(template, b1)
     assert_equal(expected, actual)
   end
+  def test_actual_csv_table_example
+    b1 = MakeBinding.().({});
+    template = <<ENDEND
+<%= csv_table(<<END, :row_header => false)
+CNE,"Older central difference model based on original CALPAS methods.  Not fully supported and not suitable for current compliance applications."
+CZM,"Conditioned zone model. Forward-difference, short time step methods are used."
+UZM,"Unconditioned zone model. Identical to CZM except heating and cooling are not supported. Typically used for attics, garages, and other ancillary spaces."
+END
+%>
+ENDEND
+  expected = <<END.strip
+--- ----------------------------------------------------------------
+CNE Older central difference model based on original CALPAS methods.
+    Not fully supported and not suitable for current compliance     
+    applications.                                                   
+
+CZM Conditioned zone model. Forward-difference, short time step     
+    methods are used.                                               
+
+UZM Unconditioned zone model. Identical to CZM except heating and   
+    cooling are not supported. Typically used for attics, garages,  
+    and other ancillary spaces.                                     
+--- ----------------------------------------------------------------
+END
+    actual = Template::RenderWithErb.(template, b1)
+    assert_equal(expected, actual)
+  end
 end

--- a/doc/test/table_test.rb
+++ b/doc/test/table_test.rb
@@ -32,4 +32,42 @@ class TableTest < TC
     actual = Template::RenderWithErb.("Hi <%= inspect %>", b2)
     assert_equal(actual, expected)
   end
+  def test_rendering_a_csv_table
+    b1 = MakeBinding.().({});
+    template = <<ENDEND
+<%= csv_table(<<END, :row_header => false)
+A,B,C
+1,2,3
+END
+%>
+ENDEND
+  expected = <<END.strip
+---------------------- ---------------------- ----------------------
+A                      B                      C                     
+
+1                      2                      3                     
+---------------------- ---------------------- ----------------------
+END
+    actual = Template::RenderWithErb.(template, b1)
+    assert_equal(expected, actual)
+  end
+  def test_rendering_a_csv_table_with_literal_comma
+    b1 = MakeBinding.().({});
+    template = <<ENDEND
+<%= csv_table(<<END, :row_header => false)
+A,B,C
+1,2,"3,4,5"
+END
+%>
+ENDEND
+  expected = <<END.strip
+---------- ---------- ---------------------------------------------
+A          B          C                                            
+
+1          2          3,4,5                                        
+---------- ---------- ---------------------------------------------
+END
+    actual = Template::RenderWithErb.(template, b1)
+    assert_equal(expected, actual)
+  end
 end


### PR DESCRIPTION
This adds tests for ensuring that csv_table works with literal commas