### PR TITLE
Fix/member table min width issue

### DIFF
--- a/doc/lib/table.rb
+++ b/doc/lib/table.rb
@@ -183,7 +183,9 @@ module Table
     def col_widths(mins, maxs)
       num_cols = mins.length
       spacing = 2 * (num_cols - 1)
-      extra_space = @max_width - (mins.inject(0, &:+) + spacing)
+      minimum_max_width = (mins.inject(0, &:+) + spacing)
+      the_max_width = if minimum_max_width > @max_width then minimum_max_width else @max_width end
+      extra_space = the_max_width - minimum_max_width
       total_max = maxs.inject(0, &:+).to_f
       width_fracs = maxs.map {|m| m / total_max}
       extra_space_alloc = width_fracs.map {|w| (w * extra_space).to_i}

--- a/doc/test/table_test.rb
+++ b/doc/test/table_test.rb
@@ -52,7 +52,7 @@ END
     assert_equal(expected, actual)
   end
   def test_rendering_a_csv_table_with_literal_comma
-    b1 = MakeBinding.().({});
+    b1 = MakeBinding.().({})
     template = <<ENDEND
 <%= csv_table(<<END, :row_header => false)
 A,B,C
@@ -71,7 +71,7 @@ END
     assert_equal(expected, actual)
   end
   def test_actual_csv_table_example
-    b1 = MakeBinding.().({});
+    b1 = MakeBinding.().({})
     template = <<ENDEND
 <%= csv_table(<<END, :row_header => false)
 CNE,"Older central difference model based on original CALPAS methods.  Not fully supported and not suitable for current compliance applications."
@@ -93,6 +93,30 @@ UZM Unconditioned zone model. Identical to CZM except heating and
     cooling are not supported. Typically used for attics, garages,  
     and other ancillary spaces.                                     
 --- ----------------------------------------------------------------
+END
+    actual = Template::RenderWithErb.(template, b1)
+    assert_equal(expected, actual)
+  end
+  def test_that_member_table_renders_well
+    b1 = MakeBinding.().({})
+    template = <<ENDEND.strip
+<%= member_table(
+  units: "W/cfm",
+  legal_range: "*x* $>$ 0",
+  default: "derived from oaSupFanEff and oaSupFanShaftBhp",
+  required: "If oaSupFanEff and oaSupFanShaftBhp not present",
+  variability: "constant") %>    
+ENDEND
+    expected = <<END.strip
+---------------------------------------------------------------------
+**Units** **Legal** **Default**      **Required**     **Variability**
+          **Range**                                                  
+--------- --------- ---------------- ---------------- ---------------
+W/cfm     *x* $>$ 0 derived from     If oaSupFanEff   constant       
+                    oaSupFanEff and  and                             
+                    oaSupFanShaftBhp oaSupFanShaftBhp                
+                                     not present                     
+---------------------------------------------------------------------
 END
     actual = Template::RenderWithErb.(template, b1)
     assert_equal(expected, actual)

--- a/doc/test/table_test.rb
+++ b/doc/test/table_test.rb
@@ -70,4 +70,31 @@ END
     actual = Template::RenderWithErb.(template, b1)
     assert_equal(expected, actual)
   end
+  def test_actual_csv_table_example
+    b1 = MakeBinding.().({});
+    template = <<ENDEND
+<%= csv_table(<<END, :row_header => false)
+CNE,"Older central difference model based on original CALPAS methods.  Not fully supported and not suitable for current compliance applications."
+CZM,"Conditioned zone model. Forward-difference, short time step methods are used."
+UZM,"Unconditioned zone model. Identical to CZM except heating and cooling are not supported. Typically used for attics, garages, and other ancillary spaces."
+END
+%>
+ENDEND
+  expected = <<END.strip
+--- ----------------------------------------------------------------
+CNE Older central difference model based on original CALPAS methods.
+    Not fully supported and not suitable for current compliance     
+    applications.                                                   
+
+CZM Conditioned zone model. Forward-difference, short time step     
+    methods are used.                                               
+
+UZM Unconditioned zone model. Identical to CZM except heating and   
+    cooling are not supported. Typically used for attics, garages,  
+    and other ancillary spaces.                                     
+--- ----------------------------------------------------------------
+END
+    actual = Template::RenderWithErb.(template, b1)
+    assert_equal(expected, actual)
+  end
 end

--- a/doc/test/table_test.rb
+++ b/doc/test/table_test.rb
@@ -32,4 +32,42 @@ class TableTest < TC
     actual = Template::RenderWithErb.("Hi <%= inspect %>", b2)
     assert_equal(actual, expected)
   end
+  def test_rendering_a_csv_table
+    b1 = MakeBinding.().({});
+    template = <<ENDEND
+<%= csv_table(<<END, :row_header => false)
+A,B,C
+1,2,3
+END
+%>
+ENDEND
+  expected = <<END.strip
+---------------------- ---------------------- ----------------------
+A                      B                      C                     
+
+1                      2                      3                     
+---------------------- ---------------------- ----------------------
+END
+    actual = Template::RenderWithErb.(template, b1)
+    assert_equal(expected, actual)
+  end
+  def test_rendering_a_csv_table_with_literal_comma
+    b1 = MakeBinding.().({});
+    template = <<ENDEND
+<%= csv_table(<<END, :row_header => false)
+A,B,C
+1,2,"3,4,5"
+END
+%>
+ENDEND
+  expected = <<END.strip
+---------- ---------- ---------------------------------------------
+A          B          C                                            
+
+1          2          3,4,5                                        
+---------- ---------- ---------------------------------------------
+END
+    actual = Template::RenderWithErb.(template, b1)
+    assert_equal(expected, actual)
+  end
 end


### PR DESCRIPTION
See if this fixes the issue you were seeing. The table now expands width if there are long variable names forcing it beyond the target "max width"