### PR TITLE
Fix/add non zero exit for coverage fail

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,8 +83,14 @@ jobs:
         run: echo "C:\Program Files (x86)\Pandoc" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Add MSVC developer commands to PATH
         uses: ilammy/msvc-dev-cmd@v1
-      - name: Build docs
+      - name: Set build to NOT do coverage check by default
+        run: rake set_coverage_off_by_default
+        working-directory: doc
+      - name: Build docs (without coverage check)
         run: rake
+        working-directory: doc
+      - name: Run coverage check
+        run: rake coverage
         working-directory: doc
       - name: Upload documentation
         uses: actions/upload-artifact@v2.2.4

--- a/doc/README.md
+++ b/doc/README.md
@@ -50,7 +50,7 @@ The specific dependencies for [Node.js] are listed in the `package.json` file.
 
 With regard to the Microsoft Build Tools, the C++ preprocessor is required in the full build process to parse parameter names from the CSE source code.
 This is accomplished with the `cl` program.
-If you type `where cl` at your prompt, then `cl` is installed and reachable.
+If you type `where cl` at your prompt and get a valid path, then `cl` is installed and reachable.
 If not, the best way to get this is to set up your Visual Studio with C++ tools (you should have this if you are able to build CSE).
 Then, to get a shell with `cl` and other tools on the path, go to `Start > Visual Studio 20XX > Developer Command Prompt for VS XX`.
 You should have access to `cl` from that prompt.

--- a/doc/README.md
+++ b/doc/README.md
@@ -335,6 +335,60 @@ When adding a new section or record you generally just open up your text editor 
 
 [some straightforward rules]: http://pandoc.org/MANUAL.html#extension-auto_identifiers
 
+## Checking for Issues
+
+The document processing system contains two quality control checking mechanisms: documentation coverage and links checks.
+
+
+### Coverage Report
+
+The coverage report can be accessed via:
+
+    > rake coverage
+
+The coverage report can be toggled to run by default or not using:
+
+    > rake set_coverage_on_by_default
+    > rake set_coverage_off_by_default
+
+Whether coverage checks run or not by default can also be changed directly by editing your local `config.yaml` file.
+Specifically, setting the `coverage?` key to true or false will set the coverage to run by default or not.
+Either way, explicitly calling `rake coverage` will always run the coverage report.
+
+The `rake coverage` check returns a non-zero exit code if any coverage issues are found.
+Certain records or fields of certain records can be ignored by specifying an `ignore-coverage` key in the YAML manifest file.
+If specified, the `ignore-coverage` dictionary-structure can contain up to two sub-fields:
+
+* records: a list of the names of records to ignore.
+  Note: if a record is ignored, none of its data fields will be compared either.
+* data-fields: a dictionary between record name and a list of data-fields to ignore
+
+An example structure appears below.
+
+```yaml
+ignore-coverage:
+  records:
+    - "airHandler"
+  data-fields:
+    export:
+      - "exTu"
+```
+
+In the example above, the "airHandler" record is completely ignored.
+In addition, the "exTu" data field of the "export" record is also ignored.
+The coverage check is accomplished by comparing the result of `cse -c` with what is in the documentation. 
+
+NOTE: the fields in ignore-coverage and the compared fields are NOT case sensitive at this time.
+However, we recommend trying to respect the case where possible should case-sensitive compare be desired in the future.
+
+
+### Link Check (i.e., Verify Links)
+
+The rake task `rake verify_links` will check the documentation for bad links.
+This can be set up to run by default during a documentation build using the local `config.yaml` file.
+Set the `verify-links?` field to true to run by default or false to disable by default.
+
+
 ## Pushing Built Documents to the Server
 
 Documents are built by default into `doc/build/output`. This directory is a check-out of the remote repository's `gh-pages` branch which uses GitHub's [GitHub Pages] functionality. The remote repository URL can be configured in the `config.yaml` file under the key `remote-repo-url`.

--- a/doc/lib/coverage_check.rb
+++ b/doc/lib/coverage_check.rb
@@ -230,7 +230,10 @@ module CoverageCheck
     records_to_ignore ||= Set.new
     record_fields_to_ignore ||= {}
     if !case_matters
-      # if case doesn't matter, downcase all keys of record_fields_to_ignore
+      # if case doesn't matter, downcase all keys
+      ris1 = ris1.keys.inject({}) {|m, k| m.merge({k.downcase => Set.new(ris1[k].map {|ris1k|ris1k.downcase})})}
+      ris2 = ris2.keys.inject({}) {|m, k| m.merge({k.downcase => Set.new(ris2[k].map {|ris2k|ris2k.downcase})})}
+      records_to_ignore = Set.new(records_to_ignore.map {|k| k.downcase})
       record_fields_to_ignore = record_fields_to_ignore.keys.inject({}) {|m, k| m.merge({k.downcase => record_fields_to_ignore[k]})}
     end
     if ris1 == ris2
@@ -247,12 +250,13 @@ module CoverageCheck
       # check fields
       fsd = :field_set_differences
       ks = ks1 & ks2
-      records_to_ignore_dc = Set.new(records_to_ignore.map {|r| r.downcase})
       ks.each do |k|
         # ignore based on lookup that is both case sensitive and insensitive
-        next if records_to_ignore.include?(k) || records_to_ignore_dc.include?(k.downcase)
-        field_ignores = record_fields_to_ignore.fetch(k, Set.new) & record_fields_to_ignore.fetch(k.downcase, Set.new)
-        diffs = SetDifferences[ris1[k], ris2[k], case_matters, field_ignores]
+        next if records_to_ignore.include?(k)
+        field_ignores = record_fields_to_ignore.fetch(k, Set.new)
+        diffs = SetDifferences[
+          ris1.fetch(k, Set.new), ris2.fetch(k, Set.new),
+          case_matters, field_ignores]
         if diffs
           if out
             out[fsd] = {} unless out.include?(fsd)

--- a/doc/lib/section_index.rb
+++ b/doc/lib/section_index.rb
@@ -16,7 +16,7 @@ module SectionIndex
       content.lines.map(&:chomp).each do |line|
         if line =~ /^#+\s+(.*)$/
           m_ += 1
-          name, slug = MD::NameAndSlug[line]
+          _, slug = MD::NameAndSlug[line]
           final_slug = "#" + slug
           idx[final_slug] = bn unless idx.include?(final_slug)
         end

--- a/doc/rakefile.rb
+++ b/doc/rakefile.rb
@@ -1872,6 +1872,7 @@ end
 
 desc "Run documentation coverage checker"
 task :coverage do
+  all_passed = true
   time_it do
     puts("#"*60)
     puts("Check CSE User Manual's Documentation Coverage")
@@ -1904,6 +1905,7 @@ task :coverage do
     ris2 = CoverageCheck::ReadAllRecordDocuments[files]
     ris3 = CoverageCheck::DropNameFieldsIfNotInRef[CoverageCheck::AdjustMap[ris2], ris1]
     diffs = CoverageCheck::RecordInputSetDifferences[ris1, ris3, false]
+    all_passed = diffs.nil?
     diff_report = CoverageCheck::RecordInputSetDifferencesToString[
       diffs, "CSE", "Documentation"
     ]
@@ -1911,6 +1913,7 @@ task :coverage do
     File.write("documentation-coverage-report.txt", diff_report)
     puts("\nCoverage Check DONE!")
     puts("^"*60)
+    exit(1) unless all_passed
   end
 end
 

--- a/doc/rakefile.rb
+++ b/doc/rakefile.rb
@@ -939,7 +939,6 @@ BuildProbesYaml = lambda do
   probes_alt_orig = DefParser::ParseCnRecs[]
   probes_alt = {}
   probes_alt_orig.keys.each do |k|
-    kdc = k.downcase
     name = probes_alt_orig[k][:name]
     probes_alt[name.downcase] = probes_alt_orig[k]
   end
@@ -957,7 +956,6 @@ BuildProbesYaml = lambda do
     next if rec_alt.nil?
     flds = probes[k][:fields]
     next if flds.empty?
-    name = k
     flds.each do |fld|
       desc = nil
       flds_alt = rec_alt[:fields].select do |f|
@@ -1890,6 +1888,13 @@ task :coverage do
         File.basename(CSE_USER_MANUAL_MANIFEST_PATH)
       )
     )
+    default_ignores = {
+      "records" => [], # ["record-name", ...],
+      "data-fields" => {
+        # "record-name" => ["field-name", ...],
+      },
+    }
+    ignores = doc.fetch("ignore-coverage", default_ignores)
     manifest = doc["sections"]
     files = manifest.map {|_, path| path}
     CheckCoverage[
@@ -1904,14 +1909,41 @@ task :coverage do
     end
     ris2 = CoverageCheck::ReadAllRecordDocuments[files]
     ris3 = CoverageCheck::DropNameFieldsIfNotInRef[CoverageCheck::AdjustMap[ris2], ris1]
-    diffs = CoverageCheck::RecordInputSetDifferences[ris1, ris3, false]
+    records_to_ignore = Set.new(ignores.fetch("records", []))
+    records_to_ignore.sort.reduce(true) do |print_header, r|
+      puts("\nIgnoring the following records (and any subsequent field discrepancies):") if print_header
+      puts("- #{r}")
+      false
+    end
+    data_fields_to_ignore = lambda do
+      dfs = ignores.fetch("data-fields", {})
+      ks = dfs.keys
+      ks.each do |k|
+        dfs[k] = Set.new(dfs[k])
+      end
+      dfs
+    end.call
+    data_fields_to_ignore.keys.sort.reduce(true) do |print_header, r|
+      puts("\nIgnoring the following fields:") if print_header
+      data_fields_to_ignore[r].sort.each {|f| puts("- #{r}:#{f}")}
+      false
+    end
+    diffs = CoverageCheck::RecordInputSetDifferences[
+      ris1, ris3, false,
+      records_to_ignore,
+      data_fields_to_ignore
+    ]
     all_passed = diffs.nil?
     diff_report = CoverageCheck::RecordInputSetDifferencesToString[
       diffs, "CSE", "Documentation"
     ]
     puts("\n\n"+diff_report)
     File.write("documentation-coverage-report.txt", diff_report)
-    puts("\nCoverage Check DONE!")
+    if all_passed
+      puts("\nCoverage Check: PASSED")
+    else
+      puts("\nCoverage Check: FAILED")
+    end
     puts("^"*60)
     exit(1) unless all_passed
   end
@@ -1931,6 +1963,24 @@ end
 desc "start an irb console in the rakefile context"
 task :irb do
   binding.irb
+end
+
+def set_local_config(key, value)
+  new_config = if File.exist?(CONFIG_FILE) then YAML.load_file(CONFIG_FILE) else {} end
+  new_config[key] = value
+  File.open(CONFIG_FILE, 'w') {|f| YAML.dump(new_config, f)}
+end
+
+desc "Set coverage report off by default by writing to local config file"
+task :set_coverage_off_by_default do
+  set_local_config("coverage?", false)
+  puts("Local config updated to not run coverage by default; Path: #{CONFIG_FILE}")
+end
+
+desc "Set coverage report on by default by writing to local config file"
+task :set_coverage_on_by_default do
+  set_local_config("coverage?", true)
+  puts("Local config updated to run coverage by default; Path: #{CONFIG_FILE}")
 end
 
 task :default => [:build_all]

--- a/doc/src/cse-user-manual.yaml
+++ b/doc/src/cse-user-manual.yaml
@@ -28,6 +28,12 @@ html-site-top: "/index.html"
 html-site-toc: "/cse-user-manual/index.html"
 css-files:
   - "/css/base.css"
+ignore-coverage:
+  records:
+    - "airHandler"
+  data-fields:
+    export:
+      - "exTu"
 sections:
   - [1, "introduction.md"]
   - [1, "operation.md"]

--- a/doc/test/coverage_check_test.rb
+++ b/doc/test/coverage_check_test.rb
@@ -437,4 +437,92 @@ class CoverageCheckTest < TC
     expected = {"A"=>Set.new(["a","b","c","cName","d"])}
     assert_equal(expected, actual)
   end
+  def test_casing_with_RecordInputSetDifferences
+    ris1 = {
+      "A" => Set.new(["aa", "ab", "ac"]),
+      "B" => Set.new(["ba", "bb", "bc"])
+    }
+    ris3 = {
+      "a" => Set.new(["AA", "AB", "AC"]),
+      "b" => Set.new(["BA", "BB", "BC"])
+    }
+    case_sensitive = false
+    records_to_ignore = ["A"]
+    data_fields_to_ignore = {"a"=>Set.new(["ac"])}
+    diffs = RecordInputSetDifferences[
+      ris1, ris3, case_sensitive,
+      records_to_ignore,
+      data_fields_to_ignore
+    ]
+    assert(diffs.nil?)
+    diffs = RecordInputSetDifferences[
+      ris3, ris1, false,
+      records_to_ignore,
+      data_fields_to_ignore
+    ]
+    assert(diffs.nil?)
+    records_to_ignore = []
+    data_fields_to_ignore = {}
+    diffs = RecordInputSetDifferences[
+      ris1, ris3, case_sensitive,
+      records_to_ignore,
+      data_fields_to_ignore
+    ]
+    assert(diffs.nil?)
+    ris1 = {
+      "A" => Set.new(["aa", "ab", "ac", "ad"]),
+      "B" => Set.new(["ba", "bb", "bc"])
+    }
+    ris3 = {
+      "a" => Set.new(["AA", "AB", "AC"]),
+      "b" => Set.new(["BA", "BC"])
+    }
+    records_to_ignore = ["B"]
+    data_fields_to_ignore = {"a"=>Set.new(["ad"])}
+    diffs = RecordInputSetDifferences[
+      ris1, ris3, case_sensitive,
+      records_to_ignore,
+      data_fields_to_ignore
+    ]
+    assert(diffs.nil?)
+    ris1 = {
+      "A" => Set.new(["aa", "ab", "ac"]),
+      "B" => Set.new(["ba", "bc"])
+    }
+    ris3 = {
+      "a" => Set.new(["AA", "AB", "AC", "AD"]),
+      "b" => Set.new(["BA", "BB", "BC"])
+    }
+    records_to_ignore = ["B"]
+    data_fields_to_ignore = {"a"=>Set.new(["ad"])}
+    diffs = RecordInputSetDifferences[
+      ris1, ris3, case_sensitive,
+      records_to_ignore,
+      data_fields_to_ignore
+    ]
+    assert(diffs.nil?)
+    ris1 = {
+      "A" => Set.new(["aa", "ab", "ac", "ae"]),
+      "B" => Set.new(["ba", "bc"])
+    }
+    ris3 = {
+      "a" => Set.new(["AA", "AB", "AC", "AD"]),
+      "b" => Set.new(["BA", "BB", "BC"])
+    }
+    records_to_ignore = ["B"]
+    data_fields_to_ignore = {"a"=>Set.new(["ad"])}
+    expected = {
+      records_in_1st_not_2nd: nil,
+      records_in_2nd_not_1st: nil,
+      field_set_differences: {
+        "a" => {in_1st_not_2nd: Set.new(["ae"]), in_2nd_not_1st: Set.new()},
+      }
+    }
+    actual = RecordInputSetDifferences[
+      ris1, ris3, case_sensitive,
+      records_to_ignore,
+      data_fields_to_ignore
+    ]
+    assert_equal(expected, actual)
+  end
 end


### PR DESCRIPTION
This causes the `rake` (or `rake coverage`) command to return a non-zero exit code if there are any coverage failures.

Let me know if you would like any changes.

Reference: #200 

NOTE: since there are coverage check issues and the purpose of this task is to return a non-zero exit code when there are coverage issues, we should see a failure on the CI (related to docs build).