### PR TITLE
Add back the check for versioning directly on a tag (removed by mistake)

### DIFF
--- a/cmake/CSEVersion.cmake
+++ b/cmake/CSEVersion.cmake
@@ -81,7 +81,11 @@ if (${GIT_STATUS} MATCHES "changed")
   set(GIT_STATUS ".dirty")
 endif()
 
-set(CSEVRSN_META "+${GIT_BRANCH}.${GIT_SHA}.${GIT_BUILD}${GIT_STATUS}")
+if(NOT ${GIT_BUILD} MATCHES "^0$")
+  set(CSEVRSN_META "+${GIT_BRANCH}.${GIT_SHA}.${GIT_BUILD}${GIT_STATUS}")
+else()
+  set(CSEVRSN_META "")
+endif()
 
 message("Building CSE ${CSEVRSN_MAJOR}.${CSEVRSN_MINOR}.${CSEVRSN_PATCH}${CSEVRSN_PRERELEASE}${CSEVRSN_META}")
 


### PR DESCRIPTION
Builds that are at a tagged revision should version CSE with the tag only; no metadata. This aspect got inadvertently removed during the semantic-versioning fix.