### PR TITLE
Sanden -> SANCO2 rebranding

### DIFF
--- a/src/CNDTYPES.DEF
+++ b/src/CNDTYPES.DEF
@@ -407,10 +407,10 @@ PIPESEGP -- "class PIPESEG*"
 			AOSMITHHPTS50 "AOSmithHPTS50"	// 50 gallon AOSmith HPTS
 			AOSMITHHPTS66 "AOSmithHPTS66"	// 66 gallon AOSmith HPTS
 			AOSMITHHPTS80 "AOSmithHPTS80"	// 80 gallon AOSmith HPTS
-			SANDEN40 "Sanden40"				// Sanden 40 gallon CO2 external heat pump
-			SANDEN80 "Sanden80"				// Sanden 80 gallon CO2 external heat pump
-			SANDEN120 "Sanden120"			// Sanden 120 gallon CO2 external heat pump
-			SANDENGS3 "SandenGS3"			// Sanden GS3 compressor CO2 external
+			SANCO2_43 "SANCO2_43|!Sanden40"				// SANCO2 43 gallon CO2 external heat pump
+			SANCO2_83 "SANCO2_83|!Sanden80"				// SANCO2 83 gallon CO2 external heat pump
+			SANCO2_119 "SANCO2_119|!Sanden120"			// SANCO2 119 gallon CO2 external heat pump
+			SANCO2_GS3 "SANCO2_GS3|!SandenGS3"			// SANCO2 GS3 compressor CO2 external
 			GE2012 "GE2012"					// 2012 era GeoSpring
 			GE2014 "GE2014"					// 2014 50 gal GE run in the efficiency mode
 			GE2014_80 "GE2014_80"			// 2014 80 gal GE model run in the efficiency mode

--- a/src/CNRECS.DEF
+++ b/src/CNRECS.DEF
@@ -4435,10 +4435,10 @@ RECORD HPWHLINK "HPWHLink" *SUBSTRUCT	// Ecotope's HPWH tank and heater
 *declare "std::vector< double> hw_pNodePowerExtra_W;"	// runtime extra tank heat linkage to HPWH
 
 *h FLOAT hw_fMixUse;				// factor for draw adjustment re HPWH setpoint > DHWSYS::ws_tUse
-									//   Some HPWHs (e.g. Sanden) have fixed (high) setpoints
+									//   Some HPWHs (e.g. SANCO2) have fixed (high) setpoints
 									//   draws are reduced to balance load at ws_tUse.
 *h FLOAT hw_fMixRL;					// factor for loop return flow adjustment re HPWH setpoint > DHWSYS::ws_tUse
-									//   Some HPWHs (e.g. Sanden) have fixed (high) setpoints
+									//   Some HPWHs (e.g. SANCO2) have fixed (high) setpoints
 									//   Loop return flow is reduced to balance load at ws_tUse.
 
 *s *e *array 2 DBL hw_inElec;		// current subhr HPWH electricity use, kWh

--- a/src/dhwcalc.cpp
+++ b/src/dhwcalc.cpp
@@ -2840,7 +2840,6 @@ RC HPWHLINK::hw_InitResistance(		// set up HPWH has EF-rated resistance heater
 	{ C_WHASHPTYCH_AOSMITHHPTS50,	 hwatSMALL | HPWH::MODELS_AOSmithHPTS50 },
 	{ C_WHASHPTYCH_AOSMITHHPTS66,	 hwatSMALL | HPWH::MODELS_AOSmithHPTS66 },
 	{ C_WHASHPTYCH_AOSMITHHPTS80,	 hwatSMALL | HPWH::MODELS_AOSmithHPTS80 },
-	{ C_WHASHPTYCH_SANDEN40,         hwatSMALL | HPWH::MODELS_Sanden40 },
 	{ C_WHASHPTYCH_GE2012,           hwatSMALL | HPWH::MODELS_GE2012 },
 	{ C_WHASHPTYCH_GE2014,           hwatSMALL | HPWH::MODELS_GE2014 },
 	{ C_WHASHPTYCH_GE2014_80,        hwatSMALL | HPWH::MODELS_GE2014_80 },
@@ -2876,9 +2875,9 @@ RC HPWHLINK::hw_InitResistance(		// set up HPWH has EF-rated resistance heater
 	{ C_WHASHPTYCH_RHEEMPLUGINDEDICATED50,hwatSMALL | HPWH::MODELS_RheemPlugInDedicated50 },
 
 	{ C_WHASHPTYCH_STIEBEL220E,      hwatSMALL | HPWH::MODELS_Stiebel220E },
-    { C_WHASHPTYCH_SANDEN40,         hwatSMALL | HPWH::MODELS_Sanden40 },
-	{ C_WHASHPTYCH_SANDEN80,         hwatSMALL | HPWH::MODELS_Sanden80 },
-	{ C_WHASHPTYCH_SANDEN120,        hwatSMALL | HPWH::MODELS_Sanden120 },
+    { C_WHASHPTYCH_SANCO2_43,         hwatSMALL | HPWH::MODELS_SANCO2_43 },
+	{ C_WHASHPTYCH_SANCO2_83,         hwatSMALL | HPWH::MODELS_SANCO2_83 },
+	{ C_WHASHPTYCH_SANCO2_119,        hwatSMALL | HPWH::MODELS_SANCO2_119 },
 
 	{ C_WHASHPTYCH_GENERIC1,         hwatSMALL | HPWH::MODELS_Generic1 },
 	{ C_WHASHPTYCH_GENERIC2,         hwatSMALL | HPWH::MODELS_Generic2 },
@@ -2891,7 +2890,7 @@ RC HPWHLINK::hw_InitResistance(		// set up HPWH has EF-rated resistance heater
 	{ C_WHASHPTYCH_AWHSTIER3GENERIC80, hwatSMALL | HPWH::MODELS_AWHSTier3Generic80 },
 
 // large
-	{ C_WHASHPTYCH_SANDENGS3,       hwatLARGE | HPWH::MODELS_Sanden_GS3_45HPA_US_SP },
+	{ C_WHASHPTYCH_SANCO2_GS3,      hwatLARGE | HPWH::MODELS_SANCO2_GS3_45HPA_US_SP },
 	{ C_WHASHPTYCH_COLMACCXV5_SP,   hwatLARGE | HPWH::MODELS_ColmacCxV_5_SP },
 	{ C_WHASHPTYCH_COLMACCXA10_SP,  hwatLARGE | HPWH::MODELS_ColmacCxA_10_SP },
 	{ C_WHASHPTYCH_COLMACCXA15_SP,  hwatLARGE | HPWH::MODELS_ColmacCxA_15_SP },
@@ -3340,7 +3339,7 @@ RC HPWHLINK::hw_DoHour(		// hourly HPWH calcs
 		hw_balErrCount = 0;
 
 	// setpoint temp: ws_tUse has hourly variability
-	//   some HPWHs (e.g. Sanden) have fixed setpoints, don't attempt
+	//   some HPWHs (e.g. SANCO2) have fixed setpoints, don't attempt
 	if (!hw_pHPWH->isSetpointFixed())
 	{	double tSetpointMax;
 		std::string whyNot;		// HPWH explanatory text, ignored

--- a/test/DHWLoop32U.cse
+++ b/test/DHWLoop32U.cse
@@ -4661,7 +4661,7 @@ DHWSYS   "dhwsys-DHWHeatpump"
    DHWHEATER   "Sandens"  
       whType = "SmallStorage"           // Type of water heater
       whHeatSrc = "ASHPX"               // Fuel source for water heater
-      whASHPType = "Sanden80"           // ASHP type (for new HPWH model)
+      whASHPType = "Sanco2_83"          // ASHP type (for new HPWH model)
       whMult = 6                        // Water heater multiplier
       whXBUEndUse = "User2"             // enduse to accumulate ASHPX backup heat elec use
       whTEx = @weather.taDbAvg          // Zone tank located in (currently active only for ASHPX model)

--- a/test/chdhw.cse
+++ b/test/chdhw.cse
@@ -6657,7 +6657,7 @@ DHWSYS   "HWSys"
    DHWHEATER   "DHWHtr1"  
       whType = "SmallStorage"           // Type of water heater
       whHeatSrc = "ASHPX"               // Fuel source for water heater
-      whASHPType = "Sanden120"           // ASHP type (for new HPWH model)
+      whASHPType = "Sanco2_119"           // ASHP type (for new HPWH model)
       whXBUEndUse = "User2"             // enduse to accumulate ASHPX backup heat elec use
       whTEx = @weather.taDbAvg
       whASHPSrcT = $tDbO   

--- a/test/ref/CHDHW.REP
+++ b/test/ref/CHDHW.REP
@@ -1768,7 +1768,7 @@ RSYS cooling subhour details for Wed 01-Jul
 
 ! Log for Run 001:
 
-! CSE 0.914.0+dhwbal.463bf40f.3.dirty for Win32 console
+! CSE 0.915.0+sanco2.acdc970e.2.dirty for Win32 console
 
 
 
@@ -3900,7 +3900,7 @@ Input for Run 001:
            DHWHEATER   "DHWHtr1"  
               whType = "SmallStorage"           // Type of water heater
               whHeatSrc = "ASHPX"               // Fuel source for water heater
-              whASHPType = "Sanden120"           // ASHP type (for new HPWH model)
+              whASHPType = "Sanco2_119"           // ASHP type (for new HPWH model)
               whXBUEndUse = "User2"             // enduse to accumulate ASHPX backup heat elec use
               whTEx = @weather.taDbAvg
               whASHPSrcT = $tDbO   
@@ -6119,7 +6119,7 @@ RSYS cooling subhour details for Wed 01-Jul
 
 ! Log for Run 002:
 
-! CSE 0.914.0+dhwbal.463bf40f.3.dirty for Win32 console
+! CSE 0.915.0+sanco2.acdc970e.2.dirty for Win32 console
 
 
 
@@ -6142,18 +6142,18 @@ Input for Run 002:
 
 
 
-! CSE 0.914.0+dhwbal.463bf40f.3.dirty for Win32 console run(s) done: Thu 11-May-23   3:59:55 pm
+! CSE 0.915.0+sanco2.acdc970e.2.dirty for Win32 console run(s) done: Tue 23-May-23  12:10:51 pm
 
 ! Executable:   d:\cse\msvc\cse.exe
-!               11-May-23   3:58 pm   (VS 14.29    2749952 bytes)  (HPWH 1.21.0)
+!               23-May-23  11:29 am   (VS 14.29    2749952 bytes)  (HPWH 1.22.0)
 ! Command line: -x!  -t1 chdhw
 ! Input file:   D:\cse\test\chdhw.cse
 ! Report file:  D:\cse\test\chdhw.rep
 
 ! Timing info --
 
-!                Input:  Time = 0.90     Calls = 2         T/C = 0.4475
+!                Input:  Time = 0.82     Calls = 2         T/C = 0.4090
 !           AutoSizing:  Time = 0.00     Calls = 0         T/C = 0.0000
-!           Simulation:  Time = 10.68    Calls = 2         T/C = 5.3385
+!           Simulation:  Time = 8.92     Calls = 2         T/C = 4.4590
 !              Reports:  Time = 0.01     Calls = 2         T/C = 0.0035
-!                Total:  Time = 11.59    Calls = 1         T/C = 11.5860
+!                Total:  Time = 9.75     Calls = 1         T/C = 9.7500

--- a/test/ref/dhwloop32U.rep
+++ b/test/ref/dhwloop32U.rep
@@ -975,7 +975,7 @@ Hourly User-defined Report, Fri 10-Jul
 
 ! Log for Run 001:
 
-! CSE 0.914.0+dhwbal.9a8f1532.6.dirty for Win32 console
+! CSE 0.915.0+sanco2.acdc970e.2.dirty for Win32 console
 
 
 
@@ -5644,7 +5644,7 @@ Input for Run 001:
            DHWHEATER   "Sandens"  
               whType = "SmallStorage"           // Type of water heater
               whHeatSrc = "ASHPX"               // Fuel source for water heater
-              whASHPType = "Sanden80"           // ASHP type (for new HPWH model)
+              whASHPType = "Sanco2_83"          // ASHP type (for new HPWH model)
               whMult = 6                        // Water heater multiplier
               whXBUEndUse = "User2"             // enduse to accumulate ASHPX backup heat elec use
               whTEx = @weather.taDbAvg          // Zone tank located in (currently active only for ASHPX model)
@@ -6139,18 +6139,18 @@ Input for Run 001:
 
 
 
-! CSE 0.914.0+dhwbal.9a8f1532.6.dirty for Win32 console run(s) done: Wed 17-May-23   2:19:25 pm
+! CSE 0.915.0+sanco2.acdc970e.2.dirty for Win32 console run(s) done: Tue 23-May-23  12:09:29 pm
 
 ! Executable:   d:\cse\msvc\cse.exe
-!               17-May-23   2:06 pm   (VS 14.29    2749952 bytes)  (HPWH 1.21.0)
-! Command line: -x!  -t1 dhwloop32U
-! Input file:   D:\cse\test\dhwloop32U.cse
-! Report file:  D:\cse\test\dhwloop32U.rep
+!               23-May-23  11:29 am   (VS 14.29    2749952 bytes)  (HPWH 1.22.0)
+! Command line: -x!  -t1 dhwloop32u
+! Input file:   D:\cse\test\dhwloop32u.cse
+! Report file:  D:\cse\test\dhwloop32u.rep
 
 ! Timing info --
 
-!                Input:  Time = 0.54     Calls = 1         T/C = 0.5420
+!                Input:  Time = 0.63     Calls = 1         T/C = 0.6270
 !           AutoSizing:  Time = 0.00     Calls = 0         T/C = 0.0000
-!           Simulation:  Time = 4.08     Calls = 1         T/C = 4.0760
+!           Simulation:  Time = 4.29     Calls = 1         T/C = 4.2940
 !              Reports:  Time = 0.01     Calls = 1         T/C = 0.0050
-!                Total:  Time = 4.63     Calls = 1         T/C = 4.6270
+!                Total:  Time = 4.93     Calls = 1         T/C = 4.9280


### PR DESCRIPTION
## Description

Support rebranding of Sanden heat pump water heaters to SANCO2.
- Change CSE internal choice constant names
- Define alias choice texts for DHWHEATER whASHPType.  Both new (e.g. "SANCO2_43") and old ("Sanden40") names are supported.
- Include HPWHsim 1.22.0 which supports new and old HPWH preset constants.
- Alter two test cases to use new choice names whASHPType.  No results changes.

Summary: this CSE is fully backwards-compatible.  CBECC modifications needed to recognize new names can be made as convenient w/o version-locking considerations.
