### PR TITLE
Support double-precision data in reports; experiment with double-precision MTR data

### DIFF
--- a/src/CNRECS.DEF
+++ b/src/CNRECS.DEF
@@ -5441,8 +5441,45 @@ RECORD MTR_IVL "meter interval sub" *SUBSTRUCT  // substruct for one meter for o
 	*declare "void mtr_Accum1( const MTR_IVL* mtrSub1, IVLCH ivl, int options=0);"
     *declare "void mtr_AccumFromSubmeter( const MTR_IVL* subMtr, float mult);"
 	*declare "double mtr_NetBldgLoad() const;"
-	*declare "RC mtr_Validate( const MTR* mtr, IVLCH ivl) const;"
+	*declare "RC mtr_Validate1( const MTR* mtr, IVLCH ivl) const;"
 
+    #if defined( METER_DBL)
+
+    *p dbl tot		// total of following specific end uses.  Code assumes precedes them.
+						//  = allEU + bt + pv
+    // Use by purpose (end use), energy used in Btu:
+    // CAUTION: order of members MATCHES DTENDUSECH choices (cndtypes.def)
+    //    for subscripting (in cnguts,cgresult.cpp) by end use -1:
+    *e dbl clg		// space cooling.  code assumes 1st member.
+    *e dbl htg		// space heating incl heat pump compressor
+    *e dbl hpBU		// heat pump resistance heating (backup and defrost)
+    *e dbl dhw		// domestic (service) hot water heating
+						//   HPWH: compressor+misc energy
+	*e dbl dhwBU		// domestic (service) hot water backup
+						//   HPWH: resistance heating energy
+						//   others: virtual backup to maintain ws_tUse
+	*e dbl dhwMFL		// domestic (service) multi-family loop energy
+						//   = DHWLOOP pump electricity + loss makeup
+    *e dbl fanC		// fans - cooling and cooling ventilation
+    *e dbl fanH		// fans - heating
+    *e dbl fanV		// fans - IAQ ventilation
+    *e dbl fan		// fans - other
+    *e dbl aux		// HVAC auxiliaries and parasitics, not including fans
+    *e dbl proc		// process energy
+    *e dbl lit		// lighting
+    *e dbl rcp		// receptacles
+    *e dbl ext		// external -- outdoor lights, etc
+    *e dbl refr		// refrigeration
+    *e dbl dish		// dish washing
+    *e dbl dry		// clothes drying
+    *e dbl wash		// clothes washing
+    *e dbl cook		// cooking
+    *e dbl usr1		// user-defined end use 1
+    *e dbl usr2		// user-defined end use 2
+	*p dbl bt			// battery output (negative)
+    *e dbl pv			// photovoltaic array output (negative)
+	*e dbl allEU		// subtotal, clg .. usr2 (= load w/o bt and pv)
+#else
     *p float tot		// total of following specific end uses.  Code assumes precedes them.
 						//  = allEU + bt + pv
     // Use by purpose (end use), energy used in Btu:
@@ -5477,6 +5514,9 @@ RECORD MTR_IVL "meter interval sub" *SUBSTRUCT  // substruct for one meter for o
 	*p float bt			// battery output (negative)
     *e float pv			// photovoltaic array output (negative)
 	*e float allEU		// subtotal, clg .. usr2 (= load w/o bt and pv)
+
+#endif  // METER_DBL
+
  // cost results. for now (11-93), must report with probes. Code (cnguts) may assume in this order, after uses.
     *p float cost		// accumulated  tot*rate
     *p float dmdCost	// largest dmd*dmdRate to month level, then accumulates (mtr_Accum)
@@ -5492,6 +5532,10 @@ RECORD MTR "meter" *RAT 	// Meter input/runtime: energy use by meter, interval, 
 	*declare "void mtr_HrInit();"
     *declare "bool mtr_HasSubmeter() const { return mtr_subMtri[ 0] != 0; }"
     *declare "void mtr_AccumFromSubmeters();"
+    *declare "RC mtr_Validate() const;"
+    *declare "MTR_IVL* mtr_GetMTRIVL( int ivl) { return &Y + (ivl - C_IVLCH_Y); }"
+    *declare "const MTR_IVL* mtr_GetMTRIVL( int ivl) const { return &Y + (ivl - C_IVLCH_Y); }"
+
 
  // inputs: rates
     *i float rate			// cost per Btu of use

--- a/src/cndefns.h
+++ b/src/cndefns.h
@@ -257,6 +257,10 @@
 #define DIM_SUBMETERLIST 51		// dimension of submeter lists in MTR, LOADMTR,
 								//   max # submeters inputable = DIM_SUBMETERLIST-1
 
+#undef METER_DBL			// define to use double for MTR_IVL end-use values
+							// (else float).  6-23 experiment, infinitesimal impact.
+							// code out when confirmed useless.
+
 #endif	// ifndef _CNDEFNS_H
 
 // cndefns.h end

--- a/src/cnguts.cpp
+++ b/src/cnguts.cpp
@@ -1370,9 +1370,10 @@ RC GAIN::gn_DoHour() const		// derive and apply hourly heat gains
 		}
 #endif
 		// accumulate DL-reduced energy consumption by meter
-		if ( mtri > 0)				// if meter given
-			// add the gain to it, reduced by any daylighting fraction (dflt 1.0)
-			MtrB.p[ mtri].H.mtr_AccumEU( gnEndUse, gnPX);
+		if (mtri > 0)				// if meter given
+		{	// add the gain to it, reduced by any daylighting fraction (dflt 1.0)
+			MtrB.p[mtri].H.mtr_AccumEU(gnEndUse, gnPX);
+		}
 
 		if (zp)		// if associated zone
 		{	if (gnEndUse==C_ENDUSECH_LIT)		// if end use is "lighting", separately accumulate
@@ -2276,7 +2277,7 @@ LOCAL void FC mtrsAccum( 	// Accumulate metered results: add interval to next, +
 
 // Not called with ivl = C_IVLCH_H
 {
-	if (ivl == C_IVLCH_D)
+	if (ivl == C_IVLCH_D)	// if accumulating hour -> day
 		SubMeterSeq.smsq_Accum();	// accumulate hour ivl from submeter(s) with possible multipliers
 									//   Submeters defined for METER and LOADMETER (4-17-2023)
 									//   Done only for hour
@@ -2302,7 +2303,7 @@ LOCAL void FC mtrsAccum( 	// Accumulate metered results: add interval to next, +
 		{
 			// compute hour's total load in each record.  .allEU then propogates to D, M, Y.
 			//  sum members .clg .. usr2 to .allEU, exclude .pv and .bt
-			mtrSub1->allEU = VSum<float,double>( &mtrSub1->clg, NENDUSES-2);  	
+			mtrSub1->allEU = VSum<decltype( mtrSub1->clg), double>(&mtrSub1->clg, NENDUSES - 2);
 
 			// compute sum of uses record (last record).  .sum record then propogates to D, M, Y.
 			if (mtr->ss < MtrB.n)   				// don't add the sum record into itself
@@ -2351,8 +2352,8 @@ LOCAL void FC mtrsFinalize( 	// Finalize meters (after post-stage calcs e.g. bat
 		   printf( "\nFinal Day=%d  hr=%d  mtr='%s' ivl=%d  ff=%d", Top.jDay, Top.iHr, mtr->name, ivl, firstflg);
 #endif
 
-		MTR_IVL* mtrSub2 = &mtr->Y + (ivl - C_IVLCH_Y);	// point destination meter interval substruct for interval
-												// ASSUMES MTR interval members ordered like DTIVLCH choices
+		MTR_IVL* mtrSub2 = mtr->mtr_GetMTRIVL( ivl);	// point destination meter interval substruct for interval
+														// ASSUMES MTR interval members ordered like DTIVLCH choices
 		MTR_IVL* mtrSub1 = mtrSub2 + 1;		// source: next shorter interval
 
 		// if hour-to-day call, compute total use, demand, and costs, then generate hour sum-of-uses record.
@@ -2374,7 +2375,7 @@ LOCAL void FC mtrsFinalize( 	// Finalize meters (after post-stage calcs e.g. bat
 			if (!Top.isWarmup)
 				// small errors seen during autosize, not understood
 				// disable check, investigate TODO, 3-2022
-				mtrSub1->mtr_Validate(mtr, ivl);
+				mtrSub1->mtr_Validate1(mtr, ivl);
 #endif
 
 			// compute sum of uses record (last record).  .sum record then propogates to D, M, Y.
@@ -2392,7 +2393,7 @@ LOCAL void FC mtrsFinalize( 	// Finalize meters (after post-stage calcs e.g. bat
 					mtrSum.mtr_Accum1( mtrSub1, ivl, 2);			// treatment of demand not necessarily sensible.
 #if defined( _DEBUG)
 				if (!Top.isWarmup)
-					mtrSub1->mtr_Validate(mtr, ivl);
+					mtrSub1->mtr_Validate1(mtr, ivl);
 #endif
 			}
 			firstRec = 0;
@@ -2414,6 +2415,11 @@ LOCAL void FC mtrsFinalize( 	// Finalize meters (after post-stage calcs e.g. bat
 	// Note: doHourGains 0's MTR hour info at start hour.
 		mtrSub2->mtr_Accum1( mtrSub1, ivl, 2 + (firstflg!=0));
 
+#if 0 && defined( _DEBUG)
+		if (!Top.isWarmup)
+			mtr->mtr_Validate();
+#endif
+
 #if	0 && defined( _DEBUG)
 		// if (bTrc)
 		{	float xTot = VSum<float,double>( &mtrSub2->clg, NENDUSES);
@@ -2423,8 +2429,19 @@ LOCAL void FC mtrsFinalize( 	// Finalize meters (after post-stage calcs e.g. bat
 #endif
 	}
 }		// mtrsFinalize
-//-----------------------------------------------------------------------------------------------------------
-RC MTR_IVL::mtr_Validate(		// validity checks w/ message(s)
+//-----------------------------------------------------------------------------
+RC MTR::mtr_Validate() const
+{
+	RC rc = RCOK;
+
+	for (int ivl = C_IVLCH_Y; ivl <= C_IVLCH_H; ivl++)
+		rc |= mtr_GetMTRIVL(ivl)->mtr_Validate1(this, ivl);
+
+	return rc;
+
+}	// MTR::mtrValidate
+//-----------------------------------------------------------------------------
+RC MTR_IVL::mtr_Validate1(		// validity checks w/ message(s)
 	const MTR* mtr,		// parent meter
 	IVLCH ivl) const	// interval being checked
 // for ad hoc tests of meter validity
@@ -2440,7 +2457,7 @@ RC MTR_IVL::mtr_Validate(		// validity checks w/ message(s)
 
 	char msgs[2000] = { 0 };
 
-	float xTot = VSum<float, double>(&clg, NENDUSES);
+	float xTot = VSum<decltype( clg), double>(&clg, NENDUSES);
 	float diff = xTot - tot;
 	if (fabs(diff) > 1.f)
 		sprintf( msgs, "Tot (%0.1f) != VSum() (%0.1f), diff = %0.1f",
@@ -2457,7 +2474,7 @@ RC MTR_IVL::mtr_Validate(		// validity checks w/ message(s)
 		rc |= mtr->orWarn( msgs);
 
 	return rc;
-}		// MTR_IVL::mtr_Validate
+}		// MTR_IVL::mtr_Validate1
 //-----------------------------------------------------------------------------------------------------------
 void MTR_IVL::mtr_Accum1( 	// accumulate of one interval into another
 
@@ -2519,7 +2536,6 @@ double MTR_IVL::mtr_NetBldgLoad() const	// building load (includes PV, excludes 
 	return allEU + pv;
 }		// MTR_IVL::mtr_NetBldgLoad
 //-----------------------------------------------------------------------------
-
 RC MTR::mtr_CkF(		// check MTR
 	int options)	// 0: check at record input
 					// 1: run setup (inter-record refs resolved)
@@ -2538,7 +2554,7 @@ RC MTR::mtr_CkF(		// check MTR
 //-----------------------------------------------------------------------------
 void MTR::mtr_HrInit()			// init prior to hour accumulation
 {
-	memset( &H.tot, 0, (NENDUSES+2)*sizeof(float));
+	memset( &H.tot, 0, (NENDUSES+2)*sizeof(decltype( H.tot)));
 						// zero H.tot, H.clg, H.htg, H.hp, H.shw, ..., H.allEU
        					// ASSUMES the NENDUSES end use members follow .tot.
 						//         and .allEU follows last end use (=.pv)

--- a/src/cvpak.cpp
+++ b/src/cvpak.cpp
@@ -129,7 +129,6 @@ char * FC cvin2sBuf( char *buf, void *data, USI dt, SI units, USI _mfw, USI _fmt
 
 // buf is NULL (for Tmpstr) or destination; other args as cvin2s (next)
 
-// formerly cvin2str(), 9-89.
 // returns buf (or Tmpstr location if NULL given).
 // Also sets Cvnchars to strlen(result).
 {

--- a/test/ref/submeter.rep
+++ b/test/ref/submeter.rep
@@ -3,16 +3,16 @@
 Error Messages for Run 001:
 
 ---------------
-SUBMETER.CSE(7115): Warning: 
+SUBMETER.CSE(7116): Warning: 
   LOADMETER 'LMHtg': Duplicate reference from LOADMETER 'LMCancel'
 ---------------
-SUBMETER.CSE(7116): Warning: 
+SUBMETER.CSE(7117): Warning: 
   LOADMETER 'LMClg': Duplicate reference from LOADMETER 'LMCancel'
 ---------------
-SUBMETER.CSE(7115): Warning: 
+SUBMETER.CSE(7116): Warning: 
   LOADMETER 'LMHtg': Duplicate reference from LOADMETER 'LMCancel'
 ---------------
-SUBMETER.CSE(7116): Warning: 
+SUBMETER.CSE(7117): Warning: 
   LOADMETER 'LMClg': Duplicate reference from LOADMETER 'LMCancel'
 ---------------
 Warning at hour/subhour 9/0 on Mon 09-Feb of simulation:
@@ -75,6 +75,27 @@ Nov -0.649      0      0      0      0      0      0      0      0      0      0
 Dec -0.450      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0 -0.450
 
 Yr  -11.12      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0 -11.12
+
+
+
+Monthly Energy Use, meter "MtrElec2"
+
+Mon    Tot    Clg    Htg   HPBU    Dhw  DhwBU DhwMFL   FanC   FanH   FanV    Fan    Aux   Proc    Lit    Rcp    Ext   Refr   Dish    Dry   Wash   Cook  User1  User2     BT     PV
+--- ------ ------ ------ ------ ------ ------ ------ ------ ------ ------ ------ ------ ------ ------ ------ ------ ------ ------ ------ ------ ------ ------ ------ ------ ------
+Jan -0.224      0      0      0      0      0      0      0      0      0      0      0      0      0  0.183      0      0      0      0      0      0      0      0      0 -0.407
+Feb -0.533      0      0      0      0      0      0      0      0      0      0      0      0      0  0.149      0      0      0      0      0      0      0      0      0 -0.683
+Mar -0.711      0      0      0      0      0      0      0      0      0      0      0      0      0  0.171      0      0      0      0      0      0      0      0      0 -0.881
+Apr -0.905      0      0      0      0      0      0      0      0      0      0      0      0      0  0.170      0      0      0      0      0      0      0      0      0 -1.075
+May -1.101      0      0      0      0      0      0      0      0      0      0      0      0      0  0.168      0      0      0      0      0      0      0      0      0 -1.270
+Jun -1.022      0      0      0      0      0      0      0      0      0      0      0      0      0  0.165      0      0      0      0      0      0      0      0      0 -1.187
+Jul -1.113      0      0      0      0      0      0      0      0      0      0      0      0      0  0.182      0      0      0      0      0      0      0      0      0 -1.295
+Aug -1.056      0      0      0      0      0      0      0      0      0      0      0      0      0  0.184      0      0      0      0      0      0      0      0      0 -1.239
+Sep -0.920      0      0      0      0      0      0      0      0      0      0      0      0      0  0.177      0      0      0      0      0      0      0      0      0 -1.097
+Oct -0.699      0      0      0      0      0      0      0      0      0      0      0      0      0  0.189      0      0      0      0      0      0      0      0      0 -0.888
+Nov -0.472      0      0      0      0      0      0      0      0      0      0      0      0      0  0.177      0      0      0      0      0      0      0      0      0 -0.649
+Dec -0.267      0      0      0      0      0      0      0      0      0      0      0      0      0  0.183      0      0      0      0      0      0      0      0      0 -0.450
+
+Yr  -9.023      0      0      0      0      0      0      0      0      0      0      0      0      0  2.098      0      0      0      0      0      0      0      0      0 -11.12
 
 
 
@@ -206,7 +227,7 @@ LMCancel
 
 ! Log for Run 001:
 
-! CSE 0.914.0+dhwbal.9a8f1532.6.dirty for Win32 console
+! CSE 0.918.0 for Win32 console
 
 
 
@@ -1281,7 +1302,8 @@ Input for Run 001:
            matCond = 0.09167                    // Conductivity (always per foot of thickness), Btuh-ft/ft2-°F
            matCondCT = 0.000122                 // Coefficient for temperature adjustment of matCond in the forward difference surface conduction model, F(-1)
         
-        METER   "MtrElec"  mtrSubmeters=MtrElecPV
+        METER   "MtrElec"  mtrSubmeters=MtrElec2
+        METER   "MtrElec2" mtrSubmeters=MtrElecPV
         METER   "MtrElecPV"  
         METER   "MtrNatGas"  
         
@@ -1595,13 +1617,13 @@ Input for Run 001:
               gnFrLat = 0.427
         
            GAIN   "Conditioned-znTV"  
-              gnMeter = "MtrElec"               // Meter that tracks internal gain
+              gnMeter = "MtrElec2"               // Meter that tracks internal gain
               gnEndUse = "Rcp"                  // Internal gain enduse
               gnPower = ((265 + (31.8 * 3)) * 3412/365) * 1 * select( $dsDay==1, 0., $ISWEHOL, TV_WEH, Default TV_WD) * TV_SM    // Expression representing internal gain power, Btuh
               gnFrRad = 0.4
         
            GAIN   "Conditioned-znSTB"  
-              gnMeter = "MtrElec"               // Meter that tracks internal gain
+              gnMeter = "MtrElec2"               // Meter that tracks internal gain
               gnEndUse = "Rcp"                  // Internal gain enduse
               gnPower = ((76 + (59.4 * 3)) * 3412/365) * 1 * select( $dsDay==1, 0., $ISWEHOL, STB_WEH, Default STB_WD) * STB_SM    // Expression representing internal gain power, Btuh
               gnFrRad = 0.2
@@ -2854,6 +2876,7 @@ Input for Run 001:
          DELETE Report "eb"
          REPORT rpType=MTR rpMeter=MtrElec rpFreq=MONTH
          REPORT rpType=MTR rpMeter=MtrElecPV rpFreq=MONTH
+         REPORT rpType=MTR rpMeter=MtrElec2 rpFreq=MONTH
          REPORT rpType=MTR rpMeter=MtrNatGas rpFreq=MONTH
         
 #        #define LMCOLS( lm, X) \
@@ -2878,27 +2901,27 @@ Input for Run 001:
          RUN
          $EOF
 -----------------------
-???     SUBMETER.CSE(7115): Warning: 
+???     SUBMETER.CSE(7116): Warning: 
 ???       LOADMETER 'LMHtg': Duplicate reference from LOADMETER 'LMCancel'
 -----------------------
-???     SUBMETER.CSE(7116): Warning: 
+???     SUBMETER.CSE(7117): Warning: 
 ???       LOADMETER 'LMClg': Duplicate reference from LOADMETER 'LMCancel'
 -----------------------
 
 
 
-! CSE 0.914.0+dhwbal.9a8f1532.6.dirty for Win32 console run(s) done: Wed 17-May-23   2:21:01 pm
+! CSE 0.918.0 for Win32 console run(s) done: Fri 23-Jun-23   6:00:44 pm
 
 ! Executable:   d:\cse\msvc\cse.exe
-!               17-May-23   2:06 pm   (VS 14.29    2749952 bytes)  (HPWH 1.21.0)
+!               23-Jun-23   5:52 pm   (VS 14.29    2749440 bytes)  (HPWH 1.22.0)
 ! Command line: -x!  -t1 submeter
 ! Input file:   D:\cse\test\submeter.cse
 ! Report file:  D:\cse\test\submeter.rep
 
 ! Timing info --
 
-!                Input:  Time = 0.80     Calls = 2         T/C = 0.3985
-!           AutoSizing:  Time = 0.43     Calls = 1         T/C = 0.4260
-!           Simulation:  Time = 5.98     Calls = 1         T/C = 5.9830
+!                Input:  Time = 0.89     Calls = 2         T/C = 0.4465
+!           AutoSizing:  Time = 0.48     Calls = 1         T/C = 0.4830
+!           Simulation:  Time = 6.77     Calls = 1         T/C = 6.7710
 !              Reports:  Time = 0.00     Calls = 1         T/C = 0.0020
-!                Total:  Time = 7.21     Calls = 1         T/C = 7.2120
+!                Total:  Time = 8.15     Calls = 1         T/C = 8.1540

--- a/test/submeter.cse
+++ b/test/submeter.cse
@@ -5605,7 +5605,8 @@ MATERIAL   "IntMassMat-Gypsum"
    matCond = 0.09167                    // Conductivity (always per foot of thickness), Btuh-ft/ft2-°F
    matCondCT = 0.000122                 // Coefficient for temperature adjustment of matCond in the forward difference surface conduction model, F(-1)
 
-METER   "MtrElec"  mtrSubmeters=MtrElecPV
+METER   "MtrElec"  mtrSubmeters=MtrElec2
+METER   "MtrElec2" mtrSubmeters=MtrElecPV
 METER   "MtrElecPV"  
 METER   "MtrNatGas"  
 
@@ -5919,13 +5920,13 @@ ZONE   "Conditioned-zn"
       gnFrLat = 0.427
 
    GAIN   "Conditioned-znTV"  
-      gnMeter = "MtrElec"               // Meter that tracks internal gain
+      gnMeter = "MtrElec2"               // Meter that tracks internal gain
       gnEndUse = "Rcp"                  // Internal gain enduse
       gnPower = ((265 + (31.8 * 3)) * 3412/365) * 1 * select( $dsDay==1, 0., $ISWEHOL, TV_WEH, Default TV_WD) * TV_SM    // Expression representing internal gain power, Btuh
       gnFrRad = 0.4
 
    GAIN   "Conditioned-znSTB"  
-      gnMeter = "MtrElec"               // Meter that tracks internal gain
+      gnMeter = "MtrElec2"               // Meter that tracks internal gain
       gnEndUse = "Rcp"                  // Internal gain enduse
       gnPower = ((76 + (59.4 * 3)) * 3412/365) * 1 * select( $dsDay==1, 0., $ISWEHOL, STB_WEH, Default STB_WD) * STB_SM    // Expression representing internal gain power, Btuh
       gnFrRad = 0.2
@@ -7178,6 +7179,7 @@ BATTERY   "battery 1"
  DELETE Report "eb"
  REPORT rpType=MTR rpMeter=MtrElec rpFreq=MONTH
  REPORT rpType=MTR rpMeter=MtrElecPV rpFreq=MONTH
+ REPORT rpType=MTR rpMeter=MtrElec2 rpFreq=MONTH
  REPORT rpType=MTR rpMeter=MtrNatGas rpFreq=MONTH
 
  #define LMCOLS( lm, X) \


### PR DESCRIPTION
## Description

Modifications to built-in report generation machinery in cgresult.cpp provide support for double-precision data.  The report scheme is table-driven with one row per report column.  A new flag allows indicating that the data being accessed is double as opposed to float.

Improved generalized data access functions added to support that change.

Testing was performed by changing MTR end use data via conditional code controlled by METER_DBL (cndefns.h).  Reported results were virtually identical to those with float data even for complex MTR schemes with submeters.  METER_DBL left #undef'd but the conditional code retained for future experiments.

Test file submeter.cse updated to better test submeters with multipliers.

