### PR TITLE
Fix rpCpl multi-run bug

### DIFF
--- a/doc/src/records/report.md
+++ b/doc/src/records/report.md
@@ -221,12 +221,12 @@ Conditional reporting flag. If given, report rows are printed only when value of
 
 **rpCPL=*int***
 
-Characters per line for a UDT (user-defined report). If widths specified in REPORTCOLs add up to more than this, a message occurs; if they total substantially less, additional whitespace is inserted between columns to make the report more readable. If rpCPL = -1, the report width determined based on required space with a single between each column.  rpCPL=0 uses the Top level *repCPL*. rpCPL is Not allowed if *rpType* is not UDT.
+Characters per line for a UDT (user-defined report). If widths specified in REPORTCOLs add up to more than this, a message occurs; if they total substantially less, additional whitespace is inserted between columns to make the report more readable. If rpCPL = -1, the report width determined based on required space with a single space between columns.  rpCPL=0 uses the Top level *repCPL*. rpCPL is not allowed if *rpType* is not UDT.
 
 <%= member_table(
   units: "",
   legal_range: "*x* $\\ge$ -1",
-  default: "as wide as needed",
+  default: "-1 (as wide as needed)",
   required: "No",
   variability: "constant") %>
 

--- a/src/cncult4.cpp
+++ b/src/cncult4.cpp
@@ -482,8 +482,7 @@ RC topRxp()			// check REPORTS and EXPORTS / build dvri info
 
 // returns non-RCOK if error.
 {
-	RI *rp;
-	RC rc;
+	RC rc = RCOK;
 
 // clear outputs of this fcn
 
@@ -501,13 +500,14 @@ RC topRxp()			// check REPORTS and EXPORTS / build dvri info
 
 // process each requested report and export
 
+	RI* rp;
 	RLUP( RiB, rp)		// loop reports input records
-		rp->ri_oneRxp();		// just below
+		rc |= rp->ri_oneRxp();		// just below
 
 	RLUP( XiB, rp)		// loop exports input records
-		rp->ri_oneRxp();
+		rc |= rp->ri_oneRxp();
 
-	return RCOK;
+	return rc;
 }			// topRxp
 //===========================================================================
 RC RI::ri_oneRxp()		// process one report or export for topRxp
@@ -865,6 +865,10 @@ badTu4ty:
 
 
 // user-defined report checks
+	int rpCplLocal = rpCpl ? rpCpl : getCpl()
+							// modifiable rpCpl, used iff UDT report (not export)
+							// don't change this->rpCpl; *this is input record)
+							//   modified value can carry over to later runs
 
 	if (rpTy)					// if good type not given, skip these type-dependent checks
 		if (rpTy != C_RPTYCH_UDT)			// not user defined
@@ -881,15 +885,14 @@ badTu4ty:
 			if (!coli)
 				oer( (char *)MH_S0563, exrp, exrePort);   	// "no %sCols given for user-defined %s"
 
-			if (!isEx  &&  coli)			// no width check for exports or if no columns
-			{	int cpl = rpCpl ? rpCpl : getCpl();		// line width
-				if (wid > cpl)
-				{	if (cpl > 0)
+			if (!isEx && coli)			// no width check for exports or if no columns
+			{	if (wid > rpCplLocal)	// if report too wide
+				{	if (rpCplLocal > 0)
 						oInfo( "%s width %d is greater than line width %d.\n"
 							"    Line width has been adjusted.",
-							exrePort, wid, cpl);
-				    // else cpl < 0 -> "as wide as needed" (w/o message)
-					rpCpl = wid;
+							exrePort, wid, rpCplLocal);
+				    // else rpCpl < 0 -> "as wide as needed" (w/o message)
+					rpCplLocal = wid;		// don't change this->rpCpl: *this is input record
 				}
 			}
 		}
@@ -961,7 +964,7 @@ badTu4ty:
 			optn |= VR_FINEWL;				// option to add newline to end of report/export at unspool
 		if (!isEx && rfp->pageFmt==C_NOYESCH_YES)	// if a report to a formatted report file
 			optn |= VR_FMT;				// spool with formatting; else unformatted for speed.
-		SI rpHeaderLocal = rpHeader;	// modifiable copy of rpHeader
+		SI rpHeaderLocal = rpHeader;	// modifiable copy of rpHeader (don't change *this = input record)
 		if (isEx)
 		{	// export file conditional header options
 			//   write header only when destination file is empty
@@ -995,7 +998,7 @@ badTu4ty:
 		}
 		if (!found)    					// if not yet in DVRI
 		{
-			char *sname, buf[100];				// re name of vr in spool, for error messages
+			const char *sname;				// re name of vr in spool, for error messages
 			switch (rpTy)
 			{
 			case C_RPTYCH_AHSIZE:
@@ -1032,6 +1035,7 @@ badTu4ty:
 				sname = "Energy Balance";
 				break;		// C_RPTYCH_ZEB
 			}
+			char buf[300];
 			sprintf( buf, "%s %s %s", sname, exrePort, Name());	// eg "Statistics report userName1", for errmsgs
 			vrOpen( &vrh, buf, optn);					// open virtual report, get handle (vrh).
 			if (DvriB.add( &dvrip, WRN)==RCOK)   		// add record to DVRI / if ok (fail unlikely after al above)
@@ -1042,7 +1046,7 @@ badTu4ty:
 				dvrip->dv_dhwMtri = ri_dhwMtri;
 				dvrip->dv_afMtri = ri_afMtri;
 				dvrip->ahi      = ahi;
-				dvrip->tui      = tui;					// 6-95
+				dvrip->tui      = tui;
 				dvrip->isExport = isExport;
 				dvrip->isAll    = isAll;
 				dvrip->rpTy     = rpTy;
@@ -1051,9 +1055,9 @@ badTu4ty:
 				dvrip->rpDayEnd = rpDayEnd;
 				dvrip->rpBtuSf  = rpBtuSf;
 				dvrip->rpCond   = rpCond;
-				dvrip->rpCondGiven = rpCondGiven; 				// may change report title
+				dvrip->rpCondGiven = rpCondGiven;	// may change report title
 				dvrip->rpTitle  = rpTitle;
-				dvrip->rpCpl    = rpCpl>0 ? rpCpl : getCpl();		// default characters per line now
+				dvrip->rpCpl    = rpCplLocal;
 				dvrip->rpHeader = rpHeaderLocal;
 				dvrip->rpFooter = rpFooter;
 				dvrip->coli     = coli;

--- a/src/cncult4.cpp
+++ b/src/cncult4.cpp
@@ -865,7 +865,7 @@ badTu4ty:
 
 
 // user-defined report checks
-	int rpCplLocal = rpCpl ? rpCpl : getCpl()
+	int rpCplLocal = rpCpl ? rpCpl : getCpl();
 							// modifiable rpCpl, used iff UDT report (not export)
 							// don't change this->rpCpl; *this is input record)
 							//   modified value can carry over to later runs

--- a/test/ref/commands.rep
+++ b/test/ref/commands.rep
@@ -131,7 +131,7 @@ Hourly Energy Balance, zone "Z2", Wed 10-Jul
 
 ! Log for Run 001:
 
-! CSE 0.918.0+command-tests.6fabc4d3.2 for Win32 console
+! CSE 0.918.0+misc-fixes.df0bb421.40.dirty for Win32 console
 
 
 
@@ -505,7 +505,7 @@ Hourly Energy Balance, zone "Z2", Wed 10-Jul
 
 ! Log for Run 002:
 
-! CSE 0.918.0+command-tests.6fabc4d3.2 for Win32 console
+! CSE 0.918.0+misc-fixes.df0bb421.40.dirty for Win32 console
 
 
 
@@ -814,7 +814,7 @@ Hourly Energy Balance, zone "Z2", Wed 10-Jul
 
 ! Log for Run 003:
 
-! CSE 0.918.0+command-tests.6fabc4d3.2 for Win32 console
+! CSE 0.918.0+misc-fixes.df0bb421.40.dirty for Win32 console
 
 
 
@@ -962,7 +962,7 @@ Hourly Energy Balance, zone "Z3", Wed 10-Jul
 
 ! Log for Run 004:
 
-! CSE 0.918.0+command-tests.6fabc4d3.2 for Win32 console
+! CSE 0.918.0+misc-fixes.df0bb421.40.dirty for Win32 console
 
 
 
@@ -1432,7 +1432,7 @@ Day   Total Unknown  Faucet  Shower    Bath  CWashr  DWashr
 
 ! Log for Run 005:
 
-! CSE 0.918.0+command-tests.6fabc4d3.2 for Win32 console
+! CSE 0.918.0+misc-fixes.df0bb421.40.dirty for Win32 console
 
 
 
@@ -2590,16 +2590,6 @@ Input for Run 005:
 
 
 
-Error Messages for Run 006:
-
----------------
-COMMANDS.CSE(1602): Info: report 'DHWREP1' of reportFile 'Primary': 
-    report width 84 is greater than line width 83.
-    Line width has been adjusted.
----------------
-
-
-
 Monthly Energy Use, meter "MtrElec"
 
 Mon    Tot    Clg    Htg   HPBU    Dhw  DhwBU DhwMFL   FanC   FanH   FanV    Fan    Aux   Proc    Lit    Rcp    Ext   Refr   Dish    Dry   Wash   Cook  User1  User2     BT     PV
@@ -3053,7 +3043,7 @@ Day   Total Unknown  Faucet  Shower    Bath  CWashr  DWashr
 
 ! Log for Run 006:
 
-! CSE 0.918.0+command-tests.6fabc4d3.2 for Win32 console
+! CSE 0.918.0+misc-fixes.df0bb421.40.dirty for Win32 console
 
 
 
@@ -3071,26 +3061,21 @@ Input for Run 006:
         RUN
         
         $EOF
------------------------
-???     COMMANDS.CSE(1602): Info: report 'DHWREP1' of reportFile 'Primary': 
-???         report width 84 is greater than line width 83.
-???         Line width has been adjusted.
------------------------
 
 
 
-! CSE 0.918.0+command-tests.6fabc4d3.2 for Win32 console run(s) done: Mon 17-Jul-23  10:20:04 am
+! CSE 0.918.0+misc-fixes.df0bb421.40.dirty for Win32 console run(s) done: Thu 20-Jul-23  12:01:02 pm
 
 ! Executable:   d:\cse\msvc\cse.exe
-!               16-Jul-23   1:29 pm   (VS 14.29    2749440 bytes)  (HPWH 1.22.0)
+!               20-Jul-23  10:56 am   (VS 14.29    2775552 bytes)  (HPWH 1.22.0)
 ! Command line: -x!  -t1 commands
 ! Input file:   D:\cse\test\commands.cse
-! Report file:  D:\cse\test\commands.rep
+! Report file:  D:\CSE\TEST\COMMANDS.REP
 
 ! Timing info --
 
-!                Input:  Time = 0.32     Calls = 6         T/C = 0.0525
+!                Input:  Time = 0.30     Calls = 6         T/C = 0.0505
 !           AutoSizing:  Time = 0.00     Calls = 0         T/C = 0.0000
-!           Simulation:  Time = 4.53     Calls = 6         T/C = 0.7555
+!           Simulation:  Time = 4.50     Calls = 6         T/C = 0.7505
 !              Reports:  Time = 0.00     Calls = 6         T/C = 0.0003
-!                Total:  Time = 4.87     Calls = 1         T/C = 4.8660
+!                Total:  Time = 4.83     Calls = 1         T/C = 4.8270


### PR DESCRIPTION
## Description

Fix bug associated with REPORT rpCpl.

Issue: When rpCpl was recalculated during setup due report-too-wide, the recalculated value was retained into subsequent runs (that is, the input record was modified).  Bad case:

1. Input or default rpCpl=-1 ("as wide as needed') in a REPORT
2. Run
3. Modify the REPORT to make it wider (e.g., add a REPORTCOL)
4. Run
5. Get superfluous warning about insufficient width.

Local value introduced to allow width recalc to occur w/o modifying input value.

Also replaced test case result commands.rep (test case commands.cse was where the problem was discovered).

Also clarified documentation for REPORT rpCpl

