### PR TITLE
Fix line number tracking and reporting (changed SI/USI values to int)

### DIFF
--- a/src/CNRECS.DEF
+++ b/src/CNRECS.DEF
@@ -1821,8 +1821,8 @@ RECORD IMPF "importFile" *RAT	// IMPORTFILE input (Impfib) and run (ImpfiB) reco
     *h BOO eof			// TRUE after last record has been used
     *h USI bufI1		// buffer subscript 1: start or next unscanned field in current record
     *h USI bufI2		// buffer subscript 2: end current record. ==bufI1 if no current record.
-    *h USI lineNo		// 1-based line number (\n count) in file
-    *r USI lineNoEndHdr		// lineNo corresponding to posEndHdr
+    *h INT lineNo		// 1-based line number (\n count) in file
+    *r INT lineNoEndHdr		// lineNo corresponding to posEndHdr
     *h *e SI nFieldsScanned	// 0 or number of fields already scanned in current record
     *h *e BOO eorScanned	// non-0 if all fields in record have been scanned
     //fields-by-number info. IFFNM.fnmt[] used to get #'s of named fields at runtime.

--- a/src/cul.cpp
+++ b/src/cul.cpp
@@ -4623,7 +4623,8 @@ RC record::oerI(    		// object error message, inner function
 	// "*** cul.cpp:oerI(); probable non-RAT record arg ***"
 
 // determine file info to show
-	USI _fileIx=0, _line=0;
+	USI _fileIx = 0;
+	int _line = 0;
 	const char* where = "";
 	if (culPhase==INPUT_PHASE)
 	{

--- a/src/cutok.cpp
+++ b/src/cutok.cpp
@@ -530,7 +530,6 @@ LOCAL void cuNottc()	// say last char not part of token body (does not unget fro
 
 /*------------------ LOCAL VARIABLES for pp interface --------------------*/
 //more variables above, incl:
-//  LOCAL USI uliFline = 0;  	// input file line # (for error messages)
 LOCAL int uliFileIx = 0; 		// "file index" of current input file, for record.fileIx, from ancrec:getFileIx
 LOCAL char* uliFname4Ix = NULL;	// text associated with uliFileIx
 LOCAL int uliEofRead = 0;		// non-0 if eof has been read to buffer

--- a/src/pp.cpp
+++ b/src/pp.cpp
@@ -91,7 +91,7 @@ struct INSTK
 	USI j;			// last+1 byte avail to ppC(), next byte for ppM()
 	USI ech;		// subscr of 1st byte NOT yet echoed to input listing
 	char *buf;		// NULL or buffer location (in heap): file buffer, theDef->text, or argV[i].
-	SI echLine;			// line # in file at buf[ech]===line # (of incomplete line) at end of lisBuf
+	int echLine;			// line # in file at buf[ech]===line # (of incomplete line) at end of lisBuf
 	void /*DEFINE*/ *theDef;	// NULL or macro DEFINE block, from symol table, in heap (for arg names)
 	char **argV;		// NULL or ptr to nA macro arg value ptrs + NULL
 };


### PR DESCRIPTION
## Description

Replaces 16-bit line number variables with 32-bit ints in a few places.  This fixes incorrect line number display in error messages generated by projects having very large input files (> 65,000-ish lines).

The known case exhibiting this problem retested OK.

All code reviewed for similar situations.  Several other 16-bit values are changed to int.

No results changes.  All tests pass.  No documentation changes.
