### PR TITLE
Improved field number type checking; correct bad usage detected

### DIFF
--- a/src/CNRECS.DEF
+++ b/src/CNRECS.DEF
@@ -1849,7 +1849,7 @@ RECORD IFFNM "impFileFldNames" *RAT	// IMPORT FILE FIELD NAMES TABLE (IffnmB) re
 //===========================================================================================================
 RECORD AUSZ "autoSizing sub" *SUBSTRUCT	// AUTOSIZING VARIABLES substructure for one autoSized member
 						// uses include:  TU .hcAs .vhAs .vcAs;  AH .hcAs .ccAs .fanAs.
-    *declare "int az_fazInit( float* xptr, BOO negFlag, record *r, SI fn, int isAusz, const char* whatFmt=NULL);"
+    *declare "int az_fazInit( float* xptr, BOO negFlag, record *r, int fn, int isAusz, const char* whatFmt=NULL);"
     *declare "void az_callPVF( void( AUSZ::*pvf)( void* pO), void* pO=nullptr);"
     *declare "void az_rddiInit( void* pO);"
     *declare "void az_begP1Dsd( void* pO);"

--- a/src/ancrec.h
+++ b/src/ancrec.h
@@ -48,18 +48,6 @@ typedef basAnc* BP;	// basAnc pointer -- formerly used to localize NEARness
 	         re field-interdependent error messages and defaults.
 	      3. may be tested by cuprobe.:probe() re input time probes. */
 
-#if 0
-// unsuccessful experiment re general fn type check, 8-2023
-template <typename T> struct FLDNUM
-{	FLDNUM(T _fn)
-	{
-		static_assert(std::is_same<int, T>::value);
-		fn = _fn;
-	}
-	int fn;
-};
-#endif
-
 //***************************************************************************************************************************
 //  class basAnc: base class for application record anchors.
 //***************************************************************************************************************************

--- a/src/ancrec.h
+++ b/src/ancrec.h
@@ -48,6 +48,18 @@ typedef basAnc* BP;	// basAnc pointer -- formerly used to localize NEARness
 	         re field-interdependent error messages and defaults.
 	      3. may be tested by cuprobe.:probe() re input time probes. */
 
+#if 0
+// unsuccessful experiment re general fn type check, 8-2023
+template <typename T> struct FLDNUM
+{	FLDNUM(T _fn)
+	{
+		static_assert(std::is_same<int, T>::value);
+		fn = _fn;
+	}
+	int fn;
+};
+#endif
+
 //***************************************************************************************************************************
 //  class basAnc: base class for application record anchors.
 //***************************************************************************************************************************
@@ -200,25 +212,35 @@ class record		// base class for records
 	}	// record::FldSet
 	float FldValFloat(int fn) const;
 	inline UCH* fStat()	// access status byte array
-	{ return (UCH *)this + b->sOff; }
-	inline UCH& fStat(int fn)	// access specific field's status bytes, lvalue use ok
-	{ return ((UCH *)this + b->sOff)[fn]; }
-	UCH fStat( int fn) const	// ditto not lvalue
-	{ return ((UCH *)this + b->sOff)[fn]; }
-	inline int IsSet( int fn) const
-	{ return (fStat( fn)&FsSET) != 0; }
+	{	return (UCH*)this + b->sOff; }
+	inline const UCH* fStat() const	// access status byte array
+	{	return (UCH*)this + b->sOff; }
+	template <typename T> inline UCH& fStat(T fn)	// access specific field's status bytes, lvalue use ok
+	{
+		static_assert(std::is_same<int, T>::value);
+		return fStat()[fn];
+	}
+	template <typename T> inline UCH fStat(T fn) const	// ditto not lvalue
+	{
+		static_assert(std::is_same<int, T>::value);
+		return fStat()[fn];
+	}
+	template <typename T> inline bool IsSet(T fn) const
+	{
+		return (fStat(fn) & FsSET) != 0;
+	}
 	RC CkSet( int fn) const;
 	int IsSetCount( int fn, ...) const;
-	inline void ClrSet( int fn)
+	template <typename T> inline void ClrSet( T fn)
 	{ fStat( fn) &= ~FsSET; }
-	inline int IsVal( int fn) const
+	template <typename T> inline bool IsVal( T fn) const
 	{ return (fStat( fn)&FsVAL) != 0; }
-	inline void ClrVal( int fn)
+	template <typename T> inline void ClrVal( T fn)
 	{ fStat(fn) &= ~FsVAL; }
 	int IsValAll( int fn, ...) const;
-	inline int IsAusz( int fn) const
+	template <typename T> inline bool IsAusz( T fn) const
 	{ return (fStat( fn)&FsAS) != 0; }
-	inline int IsSetNotAusz(int fn) const
+	template <typename T> inline bool IsSetNotAusz(T fn) const
 	{	return (fStat(fn) & (FsSET | FsAS)) == FsSET; 	}
     // override following for records with specific copying req'ts eg heap pointers to dup (dupPtrs does nothing here in base).
     // CAUTION dest's (this) must be init.

--- a/src/cnausz.cpp
+++ b/src/cnausz.cpp
@@ -751,7 +751,7 @@ int AUSZ::az_fazInit(	 // initialize AUSZ & store pointer to value being autosiz
 	float* xptr, 		// pointer to value 'x', followed by x_As and x_AsNov. Is stored.
 	BOO negFlag,		// non-0 if a negative quantity
 	record* r,			// pointer to record containing x
-	SI fn,				// x's field number (rccn.h RECORD_FIELD define), for access to field status bits
+	int fn,				// x's field number (rccn.h RECORD_FIELD define), for access to field status bits
 	int isAusz,			// TRUE if autoSize setup. Call for both phases.
 	const char* whatFmt /*=NULL*/)	// fmt for displayable ID for this AUSZ 
 									//   e.g. "AH[%s] cc" (r->Name() inserted at %s)

--- a/src/cncult2.cpp
+++ b/src/cncult2.cpp
@@ -375,7 +375,7 @@ RC TOPRAT::tp_SetCheckTimeSteps()	// initialize timesteps
 	tp_subhrDur = 1.f / tp_nSubSteps;			// subhr duration
 
 	// substep ticks = even shorter steps for e.g. HPWH simulation
-	if (!IsSet(tp_nSubhrTicks)) { // Not set
+	if (!IsSet(TOPRAT_NSUBHRTICKS)) { // Not set
 		tp_nSubhrTicks = max(1, 60 / tp_nSubSteps); // Default
 	}
 	else if (tp_nSubhrTicks != max(1, 60 / tp_nSubSteps)) {

--- a/src/cncult3.cpp
+++ b/src/cncult3.cpp
@@ -186,7 +186,7 @@ RC topSf1()
 RC SFI::sf_TopSf1()
 {
 	RC rc = RCOK;
-	RC rc1 = 0;
+	RC rc1 = RCOK;
 
 #if defined( _DEBUG)
 	Validate();
@@ -242,9 +242,9 @@ RC SFI::sf_TopSf1()
 			CSE_V x.grndRefl = CSE_V ownSf->x.grndRefl;  	// default ground reflectivity from owning surface. m-h variable.
 
 		// inherit convective model
-		if (!IsSet( IsSet( SFXI( HCMODEL))))
+		if (!IsSet(SFXI( HCMODEL)) && ownSf->IsSet( SFXI( HCMODEL)))
 			x.xs_sbcI.sb_hcModel = ownSf->x.xs_sbcI.sb_hcModel;
-		if (!IsSet( IsSet( SFXO( HCMODEL))))
+		if (!IsSet(SFXO( HCMODEL)) && ownSf->IsSet( SFXO( HCMODEL)))
 			x.xs_sbcO.sb_hcModel = ownSf->x.xs_sbcO.sb_hcModel;
 
 		if (sfc==sfcDOOR)				// note wnIhH now defl'd to 10000 (near-0 R) by CULT, 10-28-92. BRUCEDFL.
@@ -267,6 +267,7 @@ RC SFI::sf_TopSf1()
 			x.xs_model = C_SFMODELCH_QUICK;
 
 			// default area to hite*width; apply multiplier
+			
 			rc1 = CkSet( SFI_HEIGHT) | CkSet( SFI_WIDTH);	// non-RCOK if RQD ht or wid unset (msgd at end of win object)
 			if (rc1==RCOK)						// if ht & wid set (else FPE!)
 				// window area may be given explicitly, to allow using old test files where area != height * width. 2-91.

--- a/src/cnloads.cpp
+++ b/src/cnloads.cpp
@@ -2416,7 +2416,7 @@ RC RSYS::rs_TopRSys1()		// check RSYS, initial set up for run
 		                         : 50.f;	// (changed later for CHDHW)
 
 	if (rs_IsASHPPkgRoom())
-	{	if (!IsSet(rs_ASHPLockOutT))
+	{	if (!IsSet(RSYS_ASHPLOCKOUTT))
 			rs_ASHPLockOutT = 45.f;		// pkg room ASHP: use resistance at lower temps
 		rc |= rs_SetupASHP();
 	}


### PR DESCRIPTION
## Description

64-bit development found an instance of IsSet( record-member) where IsSet( record-member-field-number) was intended.

This PR includes several changes to field status access and testing functions to check that the fn (field number) is an integer.  With this, the original offending error was detected along with several more.  All have been fixed.

A more robust fix would be to define a type for field number.  An issue has been added.

No results changes.  No regression test changes.  No documentation changes.

