### PR TITLE
Code out conditionalability for IMPORT and PROBE

### DIFF
--- a/src/cueval.cpp
+++ b/src/cueval.cpp
@@ -9,32 +9,23 @@
 #include "cnglob.h"	// CSE global definitions. ASSERT.
 
 /*-------------------------------- OPTIONS --------------------------------*/
-#define PROBE	// define for features to support CSE record data probes. Undefine for portable linkability.
-#define IMPORT	// define for features to support CSE Import() function; Undefine for portable linkability. 2-94.
-
-#ifdef PROBE
 #include "srd.h"		// SFIR
 #include "ancrec.h"		// record: base class for rccn.h classes
 #include "rccn.h"		// Top.isEndOf
-#endif
 #include "msghans.h"	// MH_R0201
 
 #include "messages.h"	// msgIsHan
 #include "cvpak.h"		// cvS2Choi
 
 #include "psychro.h"	// functions in lib\psychro1/2.cpp. psyEnthalpy psyHumRat1.
-#ifdef IMPORT
 #include "impf.h"		// impFldNrN
-#endif
 
 #include "cueval.h"		// PS defines, RCUNSET; decls for fcns in this file
-#ifdef PROBE
 #include "cul.h"		// FsSET FsVAL
 #include "cuparse.h"	// evfTx     must follow cueval.h, for PSOP
 #include "cnguts.h"		// Top
 #include "cuevf.h"
 #include "exman.h"		// whatEx whatNio exInfo
-#endif
 #include "xiopak.h"
 
 
@@ -94,11 +85,9 @@ SI runtrace = 0;		// settable as sys var $runtrace (cuparse.cpp)
 /*----------------------- LOCAL FUNCTION DECLARATIONS ---------------------*/
 LOCAL RC FC cuEval( void *ip, const char** pmsg, USI *pBadH);
 LOCAL RC FC cuEvalI( const char** pmsg, USI *pBadH);
-#ifdef PROBE					// features that depend especially on being linked in CSE environmemt
 LOCAL RC FC cuRmGet( void **pv, const char** pms, USI *pBadH);
 LOCAL RC FC cuRm2Get( SI *pi, const char** pms, USI *pBadH);
 LOCAL const char * FC ivlTx( IVLCH ivl);
-#endif
 
 /*lint -e124 "Pointer to void not allowed" when comparing void ptrs */
 /*lint -e52 "Expected an lvalue" on every "((SI*)evSp)--" etc */
@@ -279,11 +268,9 @@ made things worse  TODO (MP)
 #endif
 			BP b;
 			record *e;
-#ifdef IMPORT
 			float fv;
 			int fileIx;
 			int line;
-#endif
 
 			//--- constants inline in code.  Move 4 bytes as long not float to avoid 8087 exceptions.
 		case PSKON2:
@@ -825,8 +812,6 @@ jmp:
 			printf( "%s", *SPCC++);
 			break;
 
-#ifdef PROBE	// probe-related features that depend especially on being linked in CSE environmemt
-
 			//--- record data access operations, 12-91. move up at reorder?
 		case PSRATRN:			// point record by number: ancN inline, rec number on stack, leaves record address on stack
 			b = basAnc::anc4n( *IPU++, PABT);   	// get inline anchor number, point basAnc (ancpak.cpp)
@@ -946,9 +931,6 @@ unsExprH:
 			*--SPP = p ? p : strsave("");			//   stack pointer, supplying dm "" for NULL ptr
 			dmIncRef( DMPP( p));					//   ++ ref count of copied ptr, nop if NULL
 			break;
-#endif	// PROBE
-
-#ifdef IMPORT	// Import-file related features that depend on being linked in CSE environment
 
 			//--- fetch data from fields of current record of import files. Records are read periodically elsewhere. 1-94.
 		case PSIMPLODNNR: 		// load number from field specified by field number (column number)
@@ -991,7 +973,6 @@ unsExprH:
 				goto breakbreak;			// on error, ms is set to sub-message ptr.
 			*--SPP = p;				// store returned heap pointer
 			break;
-#endif	// IMPORT
 
 		case PSCONTIN:			// continuous lighting controller with minimum power @ minimum light.
 								// does not go off. returns float fraction power requred on stack.
@@ -1066,7 +1047,6 @@ breakbreak:
 	return rc;			// RCOK if ok
 }		// cuEvalI
 
-#ifdef PROBE	// features that depend especially on being linked in CSE environmemt
 //============================================================================
 // is it time to put cuEvalI ms and pBadH in file-globals?
 LOCAL RC FC cuRmGet(
@@ -1228,9 +1208,6 @@ LOCAL RC FC cuRmGet(
 #endif
 	return RCOK;
 }			// cuRmGet
-#endif	// PROBE
-
-#ifdef PROBE	// features that depend especially on being linked in CSE environmemt
 //============================================================================
 // is it time to put cuEvalI ms and pBadH in file-globals?
 LOCAL RC FC cuRm2Get( SI *pi, const char** pms, USI *pBadH)
@@ -1266,9 +1243,6 @@ LOCAL RC FC cuRm2Get( SI *pi, const char** pms, USI *pBadH)
 	*pi = *(SI *)((char *)e + fir->fi_off); 		// fetch 2-byte value from record at offset
 	return RCOK;
 }			// cuRm2Get
-#endif
-
-#ifdef PROBE	// features that depend especially on being linked in CSE environmemt
 //============================================================================
 LOCAL const char* FC ivlTx( IVLCH ivl)	// text for interval.  general use function?
 {
@@ -1288,8 +1262,6 @@ LOCAL const char* FC ivlTx( IVLCH ivl)	// text for interval.  general use functi
 		return strtprintf( (char *)MH_R0229, (INT)ivl);	// "Bad IVLCH value %d"
 	}
 }		// ivlTx
-#endif
-
 //============================================================================
 static inline bool IsDM( DMP p)		// return nz iff string block "looks like" it is on heap
 // Constants in pseudo-code (see PSPKONN) are preceded by

--- a/src/cuparse.cpp
+++ b/src/cuparse.cpp
@@ -82,13 +82,6 @@ AGENDA items decided to defer, 10-5-90:
 
 /*-------------------------------- OPTIONS --------------------------------*/
 
-#define PROBE	// define to include code for CSE data structures "probe" feature.
-// undefine for portable linkability (without cuprobe.cpp), as to use in another project.
-
-#define IMPORT	// define to include code for Import() function to access CSE import files.
-// undefine for portable linkability (without cncult4.cpp), eg to use in another project.
-
-
 #undef EMIKONFIX	// define (and remove *'s) for change in emiKon() to fix
 					// apparent bug in konstize() found reading code 2-94.
 					///Leave unchanged till code tests out bad.
@@ -112,9 +105,7 @@ to elinate user problems with 2/3 = 0 (integer divide) and 2400*300 = 6464 (trun
 #include "cvpak.h"	// cvS2Choi
 
 #include "cnguts.h"	// Top
-#ifdef IMPORT
 #include "impf.h"	// impFcn
-#endif
 
 #include "pp.h"   	// dumpDefines(): debug aid, 9-90
 #include "sytb.h"	// symbol table: SYTBH; syXxx fcns
@@ -183,11 +174,7 @@ OPTBL opTbl[] =
 	PRASS,	CSU,	0,			0,		"=",		// CUTEQ    19 = assignment
 	25,		CSCMP,	PSIGT,		PSFGT,	">",		// CUTGT    20 >
 	13,		CSCUT,	0,			0,		"?",		// CUTQM    21 ?
-#ifdef PROBE
 	PROP,	CSCUT,	0,			0,		"@",		// CUTAT    22 @ probe
-#else
-	perr,	CSU,	0,			0,		"@",		// CUTAT    22 @
-#endif
 //  single chars [ .. ` have tok type ascii - '[' + 23
 	PROP,	CSGRP,	CUTRB,		']',	"[",		// CUTLB    23 [ grouping
 	perr,	CSU,	0,			0,		"\\",		// CUTBS    24 \ */
@@ -331,9 +318,7 @@ struct SFST : public STBK	// symbol table for each function
 };
 #define FCREG     301	// fcn cs: regular
 #define FCCHU     302	//   choose( index,v1,v2,...[default v] )  type fcns
-#ifdef IMPORT
 #define FCIMPORT 303	//   import( <impFile>,<fld Name or #)  type fcns 2-94
-#endif
 static SFST itSfs[] =
 {
 	//--id--   -----f-----  evf  -cs--  resTy   #args--argTy's--    ---codes---
@@ -379,10 +364,8 @@ static SFST itSfs[] =
 	SFST( "daily",     ROK,    EVFDAY, FCREG, TYANY,  1, TYANY, 0, 0,     0, 0),
 	SFST( "hourly",    ROK,     EVFHR, FCREG, TYANY,  1, TYANY, 0, 0,     0, 0),
 	SFST( "subhourly", ROK,  EVFSUBHR, FCREG, TYANY,  1, TYANY, 0, 0,     0, 0),
-#ifdef IMPORT
 	SFST( "import",    ROK,  0, FCIMPORT, TYFL,   2, TYID,TYSI | TYSTR,0, PSIMPLODNNR,PSIMPLODNNM),
 	SFST( "importStr", ROK,  0, FCIMPORT, TYSTR,  2, TYID,TYSI | TYSTR,0, PSIMPLODSNR,PSIMPLODSNM),
-#endif
 	SFST( "contin",    ROK,       0,   FCREG, TYFL,   4, TYFL,TYFL,TYFL,  PSCONTIN, 0),	// pwr frac = contin( mpf, mlf, sp, illum)
 	SFST( "stepped",   ROK,       0,   FCREG, TYFL,   3, TYSI,TYFL,TYFL,  PSSTEPPED,0),	// pwr frac = stepped( nsteps, sp, illum)
 	SFST( "fileInfo",  ROK,       0,   FCREG, TYSI,   1, TYSTR,  0, 0,    PSFILEINFO, 0),  // file info
@@ -658,9 +641,7 @@ LOCAL RC   FC condExpr( USI wanTy);
 #else
 LOCAL RC   FC fcn( SFST *f, USI wanTy);
 #endif
-#ifdef IMPORT
 LOCAL RC  FC fcnImport( SFST *f);
-#endif
 #if defined(LOKFCN)
 * LOCAL RC   FC fcnReg( SFST *f, SI toprec, USI wanTy);
 #else
@@ -1518,12 +1499,10 @@ LOCAL RC expr(  	// parse/compile inner recursive fcn
 				EE( var( (UVST*)stbk, wanTy) )			// do it
 				break;
 
-#ifdef PROBE
 			case CUTAT:				// @ <className>[<objectName>].<memberName>
 				NOVALUECHECK;
 				EE( probe());					// cuprobe.cpp
 				break;
-#endif
 
 			case CUTID: 			// identifier not yet in symbol table
 				NOVALUECHECK;				// added 2-92: always missing ??
@@ -1905,10 +1884,8 @@ LOCAL RC FC fcn( SFST *f, USI wanTy)		// parse built-in function reference or as
 	case FCCHU:
 		EE( fcnChoose( f, wanTy) )  break;	// choose(), hourval(), etc.  only call.
 
-#ifdef IMPORT
 	case FCIMPORT:
 		EE( fcnImport(f) )  break;		// import() and importStr() fcns. only call.
-#endif
 
 	default: //?
 #ifdef LOKFCN
@@ -1933,7 +1910,6 @@ LOCAL RC FC fcn( SFST *f, USI wanTy)		// parse built-in function reference or as
 	ERREX(fcn)
 }		// fcn
 
-#ifdef IMPORT	// undefine to link without related CSE stuff
 //==========================================================================
 LOCAL RC FC fcnImport( SFST *f)
 
@@ -2062,7 +2038,6 @@ LOCAL RC FC fcnImport( SFST *f)
 
 	return rc;
 }		// fcnImport
-#endif	// IMPORT
 
 //==========================================================================
 #ifdef LOKFCN


### PR DESCRIPTION
## Description

Minor cleanup.  cueval.cpp and cuprobe.cpp had code within #if defined( PROBE) and #if define( IMPORT).

These features are permanent and the need to link this code in other contexts does not exist.   Conditionals have been coded out.

No results or documentation changes.
