### PR TITLE
AirNet pressure warnings/errors: add user input / refine logic

### DIFF
--- a/doc/src/records/top-members.md
+++ b/doc/src/records/top-members.md
@@ -413,18 +413,18 @@ AirNet relative convergence tolerance.  See AnTolAbs just above.
 
 **ANPressWarn=*float***
 
-AirNet pressure warning threshold. A warning message is issued when the absolute value of the AirNet-calculated zone pressure exceeds ANPressWarn.  Note the default for ANPressWarn conservatively large. 5 lb/ft2 is about 250 pascals -- a pressure that is probably impossible in a building.  The intent of this value is to alert the user to incorrect modeling inputs while avoiding excessive messages.
+AirNet pressure warning threshold. A warning message is issued when the absolute value of the AirNet-calculated zone pressure exceeds ANPressWarn.  Note the default for ANPressWarn conservatively large. 10 lb/ft2 is about 500 pascals -- a pressure that is probably impossible in a building.  The intent of this value is to alert the user to incorrect modeling inputs while avoiding excessive messages.
 
 <%= member_table(
   units: "lb/ft2",
   legal_range: "x $\\gt$ 0",
-  default: "5",
+  default: "10",
   required: "No",
   variability: "constant") %>
 
 **ANPressErr=*float***
 
-AirNet pressure error threshold.  The simulation terminates with a message if the absolute value of any AirNet-calculated zone pressure exceeds ANPressErr.  Note the default value for ANPressErr is physically unrealistic.  30 lb/ft2 is about 1500 pascals -- a pressure that would never be possible in a building.  The intent of this value is to prevent simulation crashes due to numerical errors in AirNet calculations.
+AirNet pressure error threshold.  The simulation terminates with a message if the absolute value of any AirNet-calculated zone pressure exceeds ANPressErr.  Note the default value for ANPressErr is physically unrealistic. 30 lb/ft2 is about 1500 pascals -- a pressure that would never be possible in a building.  The intent of this value is to prevent simulation crashes due to numerical errors in AirNet calculations.
 
 <%= member_table(
   units: "lb/ft2",

--- a/doc/src/records/top-members.md
+++ b/doc/src/records/top-members.md
@@ -411,6 +411,29 @@ AirNet relative convergence tolerance.  See AnTolAbs just above.
   required: "No",
   variability: "constant") %>
 
+**ANPressWarn=*float***
+
+AirNet pressure warning threshold. A warning message is issued when the absolute value of the AirNet-calculated zone pressure exceeds ANPressWarn.  Note the default for ANPressWarn conservatively large. 5 lb/ft2 is about 250 pascals -- a pressure that is probably impossible in a building.  The intent of this value is to alert the user to incorrect modeling inputs while avoiding excessive messages.
+
+<%= member_table(
+  units: "lb/ft2",
+  legal_range: "x $\\gt$ 0",
+  default: "5",
+  required: "No",
+  variability: "constant") %>
+
+**ANPressErr=*float***
+
+AirNet pressure error threshold.  The simulation terminates with a message if the absolute value of any AirNet-calculated zone pressure exceeds ANPressErr.  Note the default value for ANPressErr is physically unrealistic.  30 lb/ft2 is about 1500 pascals -- a pressure that would never be possible in a building.  The intent of this value is to prevent simulation crashes due to numerical errors in AirNet calculations.
+
+<%= member_table(
+  units: "lb/ft2",
+  legal_range: "x $\\gt$ 0",
+  default: "30",
+  required: "No",
+  variability: "constant") %>
+
+
 The ASHWAT complex fenestration model used when WINDOW wnModel=ASHWAT yields several heat transfer results that are accurate over local ranges of conditions.  Several values control when these value are recalculated.  If any of the specified values changes more than the associated threshold, a full ASHWAT calculation is triggered.  Otherwise, prior results are used.  ASHWAT calculations are computationally expensive and conditions often change only incrementally between time steps.
 
 **AWTrigT=*float***

--- a/src/CNRECS.DEF
+++ b/src/CNRECS.DEF
@@ -130,14 +130,16 @@ RECORD TOPRAT "top" *RAT	/* top level RAT: contains control info and all once-on
 	*ovrcopy
 	*declare "void freeDM();"
 	*declare "const char* When( IVLCH ivl) const;"
-	*declare "int tp_IsLastStep() const { return isLastDay && isEndDay && isEndHour; }"	// TRUE iff last step of run
-	*declare "int tp_IsLastHour() const { return isLastDay && isEndDay; }"
+	*declare "bool tp_IsLastStep() const { return isLastDay && isEndDay && isEndHour; }"	// true iff last step of run
+	*declare "bool tp_IsLastHour() const { return isLastDay && isEndDay; }"
     *declare "RC FC brFileCk();"   			// checks inputs re binary results files.
     *declare "RC tp_CheckOutputFilePath( const char* filePath, const char** pMsg=NULL);"
     *declare "void tp_SetOptions();"
 	*declare "RC tp_SetDerived();"
     *declare "RC tp_SetCheckTimeSteps();"
 	*declare "RC tp_FazInit();"
+    *declare "RC tp_AirNetInit();"
+    *declare "void tp_AirNetDestroy();"
     *declare "void tp_ClearAuszFlags();"
     *declare "RC tp_Wfile( int* pHotMo);"
     *declare "RC tp_LocInit();"
@@ -233,11 +235,13 @@ RECORD TOPRAT "top" *RAT	/* top level RAT: contains control info and all once-on
 	*i FLOAT_GZ tp_AWTrigSlr;	// incident solar, fraction (default = .05)
 	*i FLOAT_GZ tp_AWTrigH;		// total surface coefficient (conv+rad), fraction (default=.1)
 
-//TOP: inputs: AirNet convergence criteria
+//TOP: inputs: AirNet convergence and error criteria
 								// a zone is deem converged iff
 								//  AMFnet <= max( tolAbs, tolRel*AMFTot)
 	*i FLOAT_GZ tp_ANTolAbs;	//   absolute tolerance, lbm/sec, dflt=.00125 (about 1 cfm)
 	*i FLOAT_GZ tp_ANTolRel;	//   relative tolerance, dflt = .0001
+    *i FLOAT_GZ tp_ANPressWarn; // AirNet pressure that triggers a warning, lb/ft2
+    *i FLOAT_GZ tp_ANPressErr;  // AirNet pressure that triggers a run-ending error, lb/ft2
 
 //TOP: inputs: other
     *i ANGLE tp_bldgAzm		// angle to add to all zone/surface azms
@@ -2455,6 +2459,9 @@ RECORD ZNR "zone" *RAT	// zone runtime info RAT.  Set mainly from separate ZNI
 									//   [ 1]=maximum (generally infil+vent)
    	*s *e *array 2 DBL zn_pz0W		// working zone pressures relative to patm at nominal z=0, lbf/sf
 									//  [ 0]=infil only; [ 1]=infil+ven
+    *y *e *array 2 INT zn_pz0WarnCount;  // # of unreasonable pressure warnings issued for this zone
+                                        //   [0]=infil only; [1]=infil+vent
+    *declare "RC zn_CheckAirNetPressure( int iV);"
 #if 0   // unused idea
 0    *declare "float zn_GetPressureAtFloorZ( int iV) const { return zn_pz0W[ iV] - i.zn_floorZ*zn_rho; }"
 #endif

--- a/src/CNRECS.DEF
+++ b/src/CNRECS.DEF
@@ -2229,6 +2229,7 @@ RECORD ZNR "zone" *RAT	// zone runtime info RAT.  Set mainly from separate ZNI
     *declare "RC zn_RadX();"
     *declare "RC zn_FFactors( struct SFPLIST& sfpList);"
     *declare "RC zn_RddInit();"
+    *declare "RC zn_RddDone( bool isAusz);"
 	*declare "RC zn_BegHour1();"
     *declare "RC zn_BegHour2();"
     *declare "RC zn_XFan();"

--- a/src/cgcomp.cpp
+++ b/src/cgcomp.cpp
@@ -2601,7 +2601,7 @@ RC AIRNET_SOLVER::an_CheckResults(
 		{
 			const ZNR* zp = ZrB.GetAt(zi + zi0);
 			if (zp->zn_pz0WarnCount[iV] > 0)
-				info("zone '%s': total mode %d pressure warning count = %d",
+				warn("zone '%s': total mode %d pressure warning count = %d",
 					zp->Name(), iV, zp->zn_pz0WarnCount[iV]);
 		}
 	}
@@ -2618,7 +2618,7 @@ RC ZNR::zn_CheckAirNetPressure(			// check zone pressure for reasonableness
 //        RCBAD if error, run should stop
 
 {	
-	static constexpr int MAXANWARNS = 100;
+	static constexpr int MAXANWARNINGMSGS = 50;	// max warning messages per zone
 	
 	RC rc = RCOK;
 	double pz0Abs = fabs( zn_pz0W[iV]);
@@ -2636,11 +2636,11 @@ RC ZNR::zn_CheckAirNetPressure(			// check zone pressure for reasonableness
 		else if (!Top.tp_autoSizing || Top.tp_pass2)
 		{
 			++zn_pz0WarnCount[iV];
-			if (zn_pz0WarnCount[iV] <= MAXANWARNS)
+			if (zn_pz0WarnCount[iV] <= MAXANWARNINGMSGS)
 				// do not set rc
 				orWarn("unreasonable mode %d pressure %0.2f lb/ft2%s",
 					iV, zn_pz0W[iV],
-					zn_pz0WarnCount[iV] == MAXANWARNS
+					zn_pz0WarnCount[iV] == MAXANWARNINGMSGS
 						? "\n    Skipping further pressure warning messages for this zone/mode."
 						: "");
 

--- a/src/cgcomp.cpp
+++ b/src/cgcomp.cpp
@@ -2593,19 +2593,8 @@ RC AIRNET_SOLVER::an_CheckResults(
 		rc |= zp->zn_CheckAirNetPressure(iV);
 	}
 
-	// if run finishing (normally or due to error)
-	//   report # of warnings
-	if (Top.tp_IsLastStep() || rc)
-	{
-		for (int zi = 0; zi < an_nz; zi++)
-		{
-			const ZNR* zp = ZrB.GetAt(zi + zi0);
-			if (zp->zn_pz0WarnCount[iV] > 0)
-				warn("zone '%s': total mode %d pressure warning count = %d",
-					zp->Name(), iV, zp->zn_pz0WarnCount[iV]);
-		}
-	}
-
+	// note zn_pz0WarnCount is reported in zn_RddDone()
+	
 	return rc;
 }	// AIRNET_SOLVER::an_CheckResults
 //-----------------------------------------------------------------------------

--- a/src/cgcomp.cpp
+++ b/src/cgcomp.cpp
@@ -2252,6 +2252,33 @@ RC IZXRAT::iz_EndSubhr()			// end-of-subhour vent calcs
 //=============================================================================
 
 ///////////////////////////////////////////////////////////////////////////////
+// Check / initialize for AirNet calcs
+///////////////////////////////////////////////////////////////////////////////
+RC TOPRAT::tp_AirNetInit()
+{
+
+	RC rc = RCOK;
+
+		// AIRNET msg triggers
+	if (Top.tp_ANPressWarn >= Top.tp_ANPressErr)
+		rc |= err("ANPressWarn (%0.1f) must be less than ANPressErr (%0.1f)", Top.tp_ANPressWarn, Top.tp_ANPressErr);
+
+	tp_pAirNet = new AIRNET();
+
+	return rc;
+
+}		// TOPRAT::tp_AirNetInit
+//-----------------------------------------------------------------------------
+void TOPRAT::tp_AirNetDestroy()
+// redundant calls OK
+{
+	delete tp_pAirNet;
+	tp_pAirNet = NULL;
+
+}	// TOPRAT::to_AirNetDestroy
+//=============================================================================
+
+///////////////////////////////////////////////////////////////////////////////
 // struct AIRNET
 //   finds zone pressures that achieve balanced mass flows
 ///////////////////////////////////////////////////////////////////////////////
@@ -2538,6 +2565,15 @@ RC AIRNET_SOLVER::an_Calc(			// airnet flow balance
 	if (!bConverge)
 		err(WRN, "%s: AirNet convergence failure", Top.When(C_IVLCH_S));
 
+	// change tiny pressures to 0
+	//   prevents trouble when doubles assigned to floats
+	for (zi = 0; zi < an_nz; zi++)
+	{
+		ZNR* zp = ZrB.GetAt(zi + zi0);
+		if (fabs(zp->zn_pz0W[iV]) < 1.e-20)
+			zp->zn_pz0W[iV] = 0.;
+	}
+
 	rc = RCOK;
 
 	TMRSTOP(TMR_AIRNET);
@@ -2548,33 +2584,71 @@ RC AIRNET_SOLVER::an_Calc(			// airnet flow balance
 RC AIRNET_SOLVER::an_CheckResults(
 	int iV)		// mode (0 or 1)
 {
-	static constexpr int MAXANERRORS = 100;
 
 	RC rc = RCOK;
-	if (an_unreasonablePressureCount >= MAXANERRORS)
-		return RCBAD;		// no further messages
-
+	
 	int zi0 = ZrB.GetSS0();
 	for (int zi = 0; zi < an_nz; zi++)
+	{	ZNR* zp = ZrB.GetAt(zi + zi0);
+		rc |= zp->zn_CheckAirNetPressure(iV);
+	}
+
+	// if run finishing (normally or due to error)
+	//   report # of warnings
+	if (Top.tp_IsLastStep() || rc)
 	{
-		ZNR* zp = ZrB.GetAt(zi + zi0);
-		if (fabs(zp->zn_pz0W[iV]) > 10.)
-		{	// zone pressure > 10 lb/ft2 (= 500 Pa approx)
-			//   notify user
-			//   ignore during early autosizing --
-			//      transient unreasonable values have been seen
-			if (!Top.tp_autoSizing || Top.tp_pass2)
-			{
-				warn(
-					"Zone '%s', %s: unreasonable mode %d pressure %0.2f lb/ft2\n",
-					zp->Name(), Top.When(C_IVLCH_S), iV, zp->zn_pz0W[iV]);
-				if (++an_unreasonablePressureCount == MAXANERRORS)
-					rc = err("Too many unreasonable zone pressures, abandoning run.");
-			}
+		for (int zi = 0; zi < an_nz; zi++)
+		{
+			const ZNR* zp = ZrB.GetAt(zi + zi0);
+			if (zp->zn_pz0WarnCount[iV] > 0)
+				info("zone '%s': total mode %d pressure warning count = %d",
+					zp->Name(), iV, zp->zn_pz0WarnCount[iV]);
 		}
 	}
+
 	return rc;
 }	// AIRNET_SOLVER::an_CheckResults
+//-----------------------------------------------------------------------------
+RC ZNR::zn_CheckAirNetPressure(			// check zone pressure for reasonableness
+	int iV)	// mode (0 or 1)
+
+// checks zone pressure against tp_ANPressWarn and tp_anPressErr
+
+// returns RCOK iff run should continue
+//        RCBAD if error, run should stop
+
+{	
+	static constexpr int MAXANWARNS = 100;
+	
+	RC rc = RCOK;
+	double pz0Abs = fabs( zn_pz0W[iV]);
+	if (pz0Abs > Top.tp_ANPressWarn)
+	{	// zone pressure > user-settable threshold
+		//   notify user
+		//   ignore during early autosizing --
+		//      transient unreasonable values have been seen
+		if (pz0Abs > Top.tp_ANPressErr)
+		{	// set rc to stop run
+			rc |= orer("mode %d pressure (%0.2f lb/ft2) exceeds ANPressErr (+/- %0.2f lb/ft2)."
+					    "\n    Abandoning run.",
+					    iV, zn_pz0W[iV], Top.tp_ANPressErr);
+		}
+		else if (!Top.tp_autoSizing || Top.tp_pass2)
+		{
+			++zn_pz0WarnCount[iV];
+			if (zn_pz0WarnCount[iV] <= MAXANWARNS)
+				// do not set rc
+				orWarn("unreasonable mode %d pressure %0.2f lb/ft2%s",
+					iV, zn_pz0W[iV],
+					zn_pz0WarnCount[iV] == MAXANWARNS
+						? "\n    Skipping further pressure warning messages for this zone/mode."
+						: "");
+
+		}
+	}
+
+	return rc;
+}		// ZNR::zn_CheckAirNetPressure
 //=============================================================================
 #else
 AIRNET::AIRNET()

--- a/src/cnausz.cpp
+++ b/src/cnausz.cpp
@@ -126,8 +126,8 @@ RC FC cgAusz()		// Autosizing entry point
 	Top.tp_ClearAuszFlags();		// error return insurance
 
 // end phase (autosize or main sim) stuff done even after initialization or run error
-	RC rc2 = cgRddDone(TRUE);		// cleanup also done (from tp_EndDesDay) after each design day. Redundant call ok. cnguts.cpp.
-	rc2 |= cgFazDone(TRUE);		// cleanup done once after all design days. cnguts.cpp.  Empty fcn 7-95.
+	RC rc2 = cgRddDone( true);		// cleanup also done (from tp_EndDesDay) after each design day. Redundant call ok. cnguts.cpp.
+	rc2 |= cgFazDone( true);		// cleanup done once after all design days. cnguts.cpp.  Empty fcn 7-95.
 	return rc ? rc : rc2;		// return exact rc from cgAuszI re ^C detection
 }				// cgAusz
 //-----------------------------------------------------------------------------------------------------------
@@ -147,7 +147,7 @@ LOCAL RC FC cgAuszI()		// Autosizing inner routine
     							//  If not verbose, continues line started in cse.cpp.
 	Top.tp_ClearAuszFlags();
 
-	CSE_EF( cgFazInit(TRUE));	// do initialization done once for all design days:
+	CSE_EF( cgFazInit( true));	// do initialization done once for all design days:
 								// Inits autoSizing & peak recording stuff in all objects.
 								// Calls AH::, TU::, HEATPLANT:: etc fazInit's, which call AUSZ::fazInit's
 								// (below, sets .az_px's, etc) & do addl object-specific init.
@@ -204,7 +204,7 @@ RC TOPRAT::tp_BegDesDay()	// init many things before start of repetitions for de
 
 	// init simulator to stardard state before each design day -- 70F zone temps, etc.
 	RC rc;
-	CSE_E( cgRddInit(TRUE));// init repeated for (main sim run or) each autoSize design day, cnguts.cpp.
+	CSE_E( cgRddInit( true));// init repeated for (main sim run or) each autoSize design day, cnguts.cpp.
 							// sets initial state of zones & systems; calls AH::rddInit's, etc.
 							// also allocs results records not used in autosizing, etc, ... .
 							// calls asRddiInit in this file: clears peaks.
@@ -258,7 +258,7 @@ RC TOPRAT::tp_EndDesDay()	// call when done with design day
 	tp_auszDsDayItr = tp_auszDsDayItrMax = 0;	// used eg in exman.cpp::rerIV
 
 // end run stuff: close weather file, import files, binRes, location, etc. cnguts.cpp.
-	RC rc = cgRddDone(TRUE);  			// may also be called at completion of phase; redundant call ok.
+	RC rc = cgRddDone( true);  			// may also be called at completion of phase; redundant call ok.
 
 	return rc;
 }			// TOPRAT::tp_EndDesDay
@@ -710,10 +710,9 @@ LOCAL WStr MakeNotDoneList()
 //===========================================================================================================
 //  cse MAIN SIMULATION support function(s) that use AUSZ stuff
 //===========================================================================================================
-RC FC asFazInit([[maybe_unused]] int isAusz)			// main sim run or autoSize phase init: portion in this file
+RC FC asFazInit([[maybe_unused]] bool isAusz)	// main sim run or autoSize phase init: portion in this file
 
 {
-	// caller: cnguts:cgFazInit() 6-95
 	return RCOK;			// empty fcn, 7-95
 }			// asFazInit
 //-----------------------------------------------------------------------------------------------------------

--- a/src/cncult.cpp
+++ b/src/cncult.cpp
@@ -2783,9 +2783,12 @@ CULT cnTopCult[] = 		// Top level table, points to all other tables, used in cal
 	CULT( "AWTrigT",	 DAT,   TOPRAT_AWTRIGT,    0,          0, VEOI,   TYFL,  0,      1.f,            N,   N),
 	CULT( "AWTrigSlr",   DAT,   TOPRAT_AWTRIGSLR,  0,          0, VEOI,   TYFL,  0,      .05f,           N,   N),
 	CULT( "AWTrigH",	 DAT,   TOPRAT_AWTRIGH,    0,          0, VEOI,   TYFL,  0,      .1f,            N,   N),
-// TOP AirNet convergence tolerances (1-2015)
+// TOP AirNet convergence tolerances and msg thresholds
 	CULT( "ANTolAbs",	 DAT,   TOPRAT_ANTOLABS,   0,          0, VEOI,   TYFL,  0,      0.00125f,       N,   N),
 	CULT( "ANTolRel",    DAT,   TOPRAT_ANTOLREL,   0,          0, VEOI,   TYFL,  0,      0.0001f,        N,   N),
+	CULT( "ANPressWarn", DAT,   TOPRAT_ANPRESSWARN,0,          0, VEOI,   TYFL,  0,      5.f,            N,   N),
+	CULT( "ANPressErr",  DAT,   TOPRAT_ANPRESSERR, 0,          0, VEOI,   TYFL,  0,      30.f,           N,   N),
+
 // TOP other
 	CULT( "bldgAzm",     DAT,   TOPRAT_BLDGAZM,    0,          0, VEOI,   TYFL,  0,      0.f,            N,   N),
 	CULT( "skymodel",    DAT,   TOPRAT_SKYMODEL,   0,          0, VEOI,   TYCH,  0,   C_SKYMODCH_ANISO,  N,   N),

--- a/src/cncult.cpp
+++ b/src/cncult.cpp
@@ -2786,7 +2786,7 @@ CULT cnTopCult[] = 		// Top level table, points to all other tables, used in cal
 // TOP AirNet convergence tolerances and msg thresholds
 	CULT( "ANTolAbs",	 DAT,   TOPRAT_ANTOLABS,   0,          0, VEOI,   TYFL,  0,      0.00125f,       N,   N),
 	CULT( "ANTolRel",    DAT,   TOPRAT_ANTOLREL,   0,          0, VEOI,   TYFL,  0,      0.0001f,        N,   N),
-	CULT( "ANPressWarn", DAT,   TOPRAT_ANPRESSWARN,0,          0, VEOI,   TYFL,  0,      5.f,            N,   N),
+	CULT( "ANPressWarn", DAT,   TOPRAT_ANPRESSWARN,0,          0, VEOI,   TYFL,  0,      10.f,           N,   N),
 	CULT( "ANPressErr",  DAT,   TOPRAT_ANPRESSERR, 0,          0, VEOI,   TYFL,  0,      30.f,           N,   N),
 
 // TOP other

--- a/src/cncult2.cpp
+++ b/src/cncult2.cpp
@@ -455,20 +455,21 @@ RC TOPRAT::tp_FazInit()	// start-of-phase init
 #if defined( DEBUGDUMP)
 	DbDo(dbdSTARTRUN);		// init debug print scheme (re heading control)
 	tp_SetDbMask();		// debug printout mask (dbdXXX), controls internal val dumping
-							//   (can change hourly, set initial value here re print from setup code)
+	//   (can change hourly, set initial value here re print from setup code)
 #endif
 
 //---- find/read weather file name / get lat, long, tz, default elevation, default autosizing stuff. 1-95.
 	int hotMo = 7;				// hottest month 1-12, wthr file hdr to topAusz, July if not set by topWfile
 	CSE_E(tp_Wfile(&hotMo))		// just below. call b4 topAusz.
 
-//---- autosizing setup. call after topWfile. 6-95.
-	CSE_E(tp_Ausz(hotMo))
+		//---- autosizing setup. call after topWfile. 6-95.
+		CSE_E(tp_Ausz(hotMo))
 
-//---- say various texts should be (re)generated before (any further) use as may have new runTitle, repHdrL/R.
-	freeRepTexts();				// cncult4.cpp
+		//---- say various texts should be (re)generated before (any further) use as may have new runTitle, repHdrL/R.
+		freeRepTexts();				// cncult4.cpp
 
-	tp_pAirNet = new AIRNET();
+	// check and set up AIRNET
+	rc |= tp_AirNetInit();
 
 	return rc;
 }			// TOPRAT::tp_fazInit
@@ -827,8 +828,7 @@ void TOPRAT::freeDM()		// free child objects in DM
 	tp_brFileName.Release();
 #endif
 
-	delete tp_pAirNet;
-	tp_pAirNet = NULL;
+	tp_AirNetDestroy();		// cleanup / delete AirNet machinery
 
 	tp_PumbraDestroy();		// cleanup / delete Penumbra shading machinery
 

--- a/src/cnguts.h
+++ b/src/cnguts.h
@@ -222,19 +222,16 @@ void FC cgInit();		// init before all phases
 void FC cgDone();		// cleanup after all phases
 void FC runFazDataFree();
 // bool DbDo( DWORD oMsk);	// decl in cnglob.h
-RC   FC cgFazInit( int isAusz);	// init done for main sim or autosize -- once before all design days
-RC   FC cgRddInit( int isAusz);	// init done for main sim run or each autoSize design day
-RC   FC cgRddDone( int isAusz);	// cleanup for main sim run or each autoSize design day
-RC   FC cgFazDone( int isAusz);	// cleanup for main sim or autosize -- once after all design days
+RC   FC cgFazInit( bool isAusz);	// init done for main sim or autosize -- once before all design days
+RC   FC cgRddInit( bool isAusz);	// init done for main sim run or each autoSize design day
+RC   FC cgRddDone( bool isAusz);	// cleanup for main sim run or each autoSize design day
+RC   FC cgFazDone( bool isAusz);	// cleanup for main sim or autosize -- once after all design days
 RC cgSubMeterSetup();			// initialize for submeter accumulation
 
 // cnausz.cpp
-RC   FC cgAusz();		// 6-95
-RC   FC asFazInit(int isAusz);	// 6-95
-RC   FC asRddiInit();		// 6-95
-#if 0
-  RC   FC asmsAfterWarmup();	// 6-95
-#endif
+RC   FC cgAusz();
+RC   FC asFazInit(bool isAusz);
+RC   FC asRddiInit();
 
 // cnloads.cpp
 RC   FC loadsHourBeg();

--- a/src/cnloads.cpp
+++ b/src/cnloads.cpp
@@ -151,6 +151,7 @@ RC ZNR::zn_RddInit()
 	haMass = 0.;				// +='d in ms_rddInit. pre-0'd object may be re-used in autoSizing.
 	znXLGain = znXLGainLs = 0;	// no condensation heat leftover from prior iteration, rob 6-11-97
 	zn_ebErrCount = 0;			// count of short-interval energy balance errors
+	zn_pz0WarnCount[0] = zn_pz0WarnCount[1] = 0;
 
 	// HVAC convective delivery fraction
 	//   needs elaboration for radiant systems

--- a/src/cnloads.cpp
+++ b/src/cnloads.cpp
@@ -159,6 +159,31 @@ RC ZNR::zn_RddInit()
 
 	return RCOK;
 }		// ZNR::zn_RddInit()
+//-----------------------------------------------------------------------------
+RC ZNR::zn_RddDone(		// called at end of simulation and each autosize design day
+	bool isAusz)	// true: autosize
+					// false: simulation
+// duplicate calls harmless
+// NOTE: clears zn_pz0WarnCount[]
+// 
+// returns RCOK iff all OK
+{
+	RC rc = RCOK;
+
+	// report count of AirNet pressure warnings
+	//   see AIRNET_SOLVER::an_CheckResults() and ZNR::zn_CheckAirNetPressure()
+	if (zn_pz0WarnCount[0] > 0 || zn_pz0WarnCount[1] > 0)
+	{
+		warn("Zone '%s': %s unreasonable pressure warning counts --"
+			"\n    mode 0 = %d / mode 1 = %d",
+			Name(),
+			isAusz ? strtprintf("%s autosizing", Top.tp_AuszDoing()) : "Simulation",
+			zn_pz0WarnCount[0], zn_pz0WarnCount[1]);
+		zn_pz0WarnCount[0] = zn_pz0WarnCount[1] = 0;	// prevent duplicate msg
+	}
+
+	return rc;
+}		// ZNR::zn_RddDone
 //====================================================================
 RC FC loadsHourBeg()		// start of hour loads stuff: solar gains, hourly masses, zones init, .
 

--- a/test/ASHPTest2.cse
+++ b/test/ASHPTest2.cse
@@ -672,7 +672,7 @@ IZXFER   "Conditioned-xAttic"
 IZXFER   "Conditioned-IAQFanE"  
    izNVType = "AIRNETEXTFAN"
    izZn1 = "Conditioned-zn"
-   izVFmin = -51
+   izVFmin = $dayOfYear==jul 10 && $hour==12 ? 5000 : -51
    izVFmax = -51
    izFanVfDs = 51
    izFanElecPwr = 0.25

--- a/test/ASHPTest2.cse
+++ b/test/ASHPTest2.cse
@@ -674,7 +674,7 @@ IZXFER   "Conditioned-xAttic"
 IZXFER   "Conditioned-IAQFanE"  
    izNVType = "AIRNETEXTFAN"
    izZn1 = "Conditioned-zn"
-   izVFmin = $dayOfYear==jul 10 && $hour==12 ? 5000 : -51
+   izVFmin = $dayOfYear==Jun 30 && $hour==12 ? 5000 : -51
    izVFmax = -51
    izFanVfDs = 51
    izFanElecPwr = 0.25

--- a/test/ASHPTest2.cse
+++ b/test/ASHPTest2.cse
@@ -17,6 +17,8 @@
    dt = "YES"
    heatDsTDbO = 37
    coolDsDay = DD1
+   ANPressWarn = 5.78   // airnet pressure warning threshold
+                        //   triggers a few warnings for testing
 
 MATERIAL   "mat-Gypsum Board"  
    matDens = 40

--- a/test/ref/ASHPPKGROOM.REP
+++ b/test/ref/ASHPPKGROOM.REP
@@ -458,7 +458,7 @@ Top
    jan1DoW               6   8    16384  0   1     16                       nz        0           0         0       
    wuDays                6   10   16384  0   1     1                        nz        0           0         0       
    nSubSteps             6   11   16384  0   1     1                        nz        0           0         0       
-   nSubhrTicks           6   178  0      0   1     1                        0         0           0         0       
+   nSubhrTicks           6   180  0      0   1     1                        0         0           0         0       
    wfName                6   12   16392  0   3     4                        0         0           0         0       
    TDVfName              6   13   0      0   3     4                        0         0           0         0       
    elevation             6   14   0      0   3     2                        0         0           0         0       
@@ -491,44 +491,46 @@ Top
    AWTrigH               6   42   0      0   1     2                        0         0.1         0         0       
    ANTolAbs              6   43   0      0   1     2                        0         0.00125     0         0       
    ANTolRel              6   44   0      0   1     2                        0         0.0001      0         0       
-   bldgAzm               6   45   0      0   1     2                        0         0           0         0       
-   skymodel              6   46   16384  0   1     16                       nz        0           0         0       
-   skymodelLW            6   47   0      0   1     16                       nz        0           0         0       
-   exShadeModel          6   48   0      0   1     16                       nz        0           0         0       
-   slrInterpMeth         6   49   0      0   1     16                       nz        0           0         0       
-   humMeth               6   50   0      0   1     16                       nz        0           0         0       
-   dflExH                6   51   0      0   1     2                        0         2.64        0         0       
-   workDayMask           6   52   0      0   1     1                        nz        0           0         0       
-   DT                    6   53   16384  0   1     16                       nz        0           0         0       
-   DTbegDay              6   54   0      0   1     28672                    0         0           0         0       
-   DTendDay              6   55   0      0   1     28672                    0         0           0         0       
-   terrainClass          6   58   0      0   1     1                        nz        0           0         0       
-   windSpeedMin          6   56   0      0   1     2                        0         0.5         0         0       
-   windF                 6   57   0      0   1     2                        0         1           0         0       
-   radBeamF              6   59   0      0   1     2                        0         1           0         0       
-   radDiffF              6   60   0      0   1     2                        0         1           0         0       
-   hConvMod              6   63   0      0   1     16                       nz        0           0         0       
-   verbose               6   64   0      0   1     1                        nz        0           0         0       
-   dbgPrintMask          6   65   0      0   739   32                       0         0           0         0       
-   dbgPrintMaskC         6   66   16384  0   1     32                       0         0           0         0       
-   dbgFlag               6   67   0      0   1763  32                       0         0           0         0       
-   ventAvail             6   61   0      0   739   16                       nz        0           0         0       
-   auszTol               6   68   0      0   1     2                        0         0.005       0         0       
-   heatDsTDbO            6   69   16384  0   739   2                        0         0           0         0       
-   heatDsTWbO            6   70   0      0   739   2                        0         0           0         0       
-   coolDsMo              6   71   128    0   1     1                        0         0           nz        0       
-   coolDsDay             6   84   16512  0   1     28672                    0         0           nz        0       
-   coolDsCond            6   97   128    0   1     8192   DESCOND           0         0           nz        0       
-   runSerial             6   116  0      0   1     1                        0         0           0         0       
-   runTitle              6   117  0      0   1     4                        0         0           0         0       
-   repHdrL               6   124  16384  0   1     4                        0         0           0         0       
-   repHdrR               6   125  0      0   1     4                        0         0           0         0       
-   repCpl                6   126  0      0   1     1                        nz        0           0         0       
-   repLpp                6   127  0      0   1     1                        nz        0           0         0       
-   repTopM               6   128  0      0   1     1                        nz        0           0         0       
-   repBotM               6   129  0      0   1     1                        nz        0           0         0       
-   repTestPfx            6   130  0      0   1     4                        0         0           0         0       
-   ck5aa5                6   285  4      0   0     1                        nz        0           0         0       
+   ANPressWarn           6   45   0      0   1     2                        0         5           0         0       
+   ANPressErr            6   46   0      0   1     2                        0         30          0         0       
+   bldgAzm               6   47   0      0   1     2                        0         0           0         0       
+   skymodel              6   48   16384  0   1     16                       nz        0           0         0       
+   skymodelLW            6   49   0      0   1     16                       nz        0           0         0       
+   exShadeModel          6   50   0      0   1     16                       nz        0           0         0       
+   slrInterpMeth         6   51   0      0   1     16                       nz        0           0         0       
+   humMeth               6   52   0      0   1     16                       nz        0           0         0       
+   dflExH                6   53   0      0   1     2                        0         2.64        0         0       
+   workDayMask           6   54   0      0   1     1                        nz        0           0         0       
+   DT                    6   55   16384  0   1     16                       nz        0           0         0       
+   DTbegDay              6   56   0      0   1     28672                    0         0           0         0       
+   DTendDay              6   57   0      0   1     28672                    0         0           0         0       
+   terrainClass          6   60   0      0   1     1                        nz        0           0         0       
+   windSpeedMin          6   58   0      0   1     2                        0         0.5         0         0       
+   windF                 6   59   0      0   1     2                        0         1           0         0       
+   radBeamF              6   61   0      0   1     2                        0         1           0         0       
+   radDiffF              6   62   0      0   1     2                        0         1           0         0       
+   hConvMod              6   65   0      0   1     16                       nz        0           0         0       
+   verbose               6   66   0      0   1     1                        nz        0           0         0       
+   dbgPrintMask          6   67   0      0   739   32                       0         0           0         0       
+   dbgPrintMaskC         6   68   16384  0   1     32                       0         0           0         0       
+   dbgFlag               6   69   0      0   1763  32                       0         0           0         0       
+   ventAvail             6   63   0      0   739   16                       nz        0           0         0       
+   auszTol               6   70   0      0   1     2                        0         0.005       0         0       
+   heatDsTDbO            6   71   16384  0   739   2                        0         0           0         0       
+   heatDsTWbO            6   72   0      0   739   2                        0         0           0         0       
+   coolDsMo              6   73   128    0   1     1                        0         0           nz        0       
+   coolDsDay             6   86   16512  0   1     28672                    0         0           nz        0       
+   coolDsCond            6   99   128    0   1     8192   DESCOND           0         0           nz        0       
+   runSerial             6   118  0      0   1     1                        0         0           0         0       
+   runTitle              6   119  0      0   1     4                        0         0           0         0       
+   repHdrL               6   126  16384  0   1     4                        0         0           0         0       
+   repHdrR               6   127  0      0   1     4                        0         0           0         0       
+   repCpl                6   128  0      0   1     1                        nz        0           0         0       
+   repLpp                6   129  0      0   1     1                        nz        0           0         0       
+   repTopM               6   130  0      0   1     1                        nz        0           0         0       
+   repBotM               6   131  0      0   1     1                        nz        0           0         0       
+   repTestPfx            6   132  0      0   1     4                        0         0           0         0       
+   ck5aa5                6   287  4      0   0     1                        nz        0           0         0       
    material              5   0    16400  0   0     0      material          0         0           494       0       
    construction          5   0    16400  0   0     0      construction      0         0           483       0       
    foundation            5   0    16     0   0     0      foundation        0         0           471       0       
@@ -2002,7 +2004,7 @@ inverse    Parent: Top
    ivX                   6   6    8      0   1771  2                        0         0           0         0       
    ivY                   6   7    8      0   1771  2                        0         0           0         0       
    endInverse            13  0    0      0   0     0                        0         0           0         0       
-! CSE 0.918.0+64-bit-debug.a86734de.95.dirty for Win32 console
+! CSE 0.919.0 for Win32 console
 
 
 
@@ -3565,18 +3567,18 @@ Input for Run 001:
 
 
 
-! CSE 0.918.0+64-bit-debug.a86734de.95.dirty for Win32 console run(s) done: Thu 28-Sep-23   4:19:55 pm
+! CSE 0.919.0 for Win32 console run(s) done: Fri 13-Oct-23   4:41:58 pm
 
 ! Executable:   d:\cse\msvc\cse.exe
-!               28-Sep-23   4:12 pm   (VS 14.29    2785280 bytes)  (HPWH 1.22.0+HEAD.d205413.4)
+!               13-Oct-23   4:32 pm   (VS 14.29    2796544 bytes)  (HPWH 1.22.0+HEAD.d205413.4)
 ! Command line: -x!  -t1 ashppkgroom
 ! Input file:   D:\cse\test\ashppkgroom.cse
 ! Report file:  D:\CSE\TEST\ASHPPKGROOM.REP
 
 ! Timing info --
 
-!                Input:  Time = 0.10     Calls = 2         T/C = 0.0475
-!           AutoSizing:  Time = 0.30     Calls = 1         T/C = 0.2980
-!           Simulation:  Time = 6.70     Calls = 1         T/C = 6.7040
+!                Input:  Time = 0.10     Calls = 2         T/C = 0.0490
+!           AutoSizing:  Time = 0.27     Calls = 1         T/C = 0.2690
+!           Simulation:  Time = 6.66     Calls = 1         T/C = 6.6570
 !              Reports:  Time = 0.00     Calls = 1         T/C = 0.0020
-!                Total:  Time = 7.11     Calls = 1         T/C = 7.1080
+!                Total:  Time = 7.03     Calls = 1         T/C = 7.0340

--- a/test/ref/ASHPPKGROOM.REP
+++ b/test/ref/ASHPPKGROOM.REP
@@ -491,7 +491,7 @@ Top
    AWTrigH               6   42   0      0   1     2                        0         0.1         0         0       
    ANTolAbs              6   43   0      0   1     2                        0         0.00125     0         0       
    ANTolRel              6   44   0      0   1     2                        0         0.0001      0         0       
-   ANPressWarn           6   45   0      0   1     2                        0         5           0         0       
+   ANPressWarn           6   45   0      0   1     2                        0         10          0         0       
    ANPressErr            6   46   0      0   1     2                        0         30          0         0       
    bldgAzm               6   47   0      0   1     2                        0         0           0         0       
    skymodel              6   48   16384  0   1     16                       nz        0           0         0       
@@ -2004,7 +2004,7 @@ inverse    Parent: Top
    ivX                   6   6    8      0   1771  2                        0         0           0         0       
    ivY                   6   7    8      0   1771  2                        0         0           0         0       
    endInverse            13  0    0      0   0     0                        0         0           0         0       
-! CSE 0.919.0 for Win32 console
+! CSE 0.919.0+airnet-msg-control.ec6c303d.4.dirty for Win32 console
 
 
 
@@ -3567,18 +3567,18 @@ Input for Run 001:
 
 
 
-! CSE 0.919.0 for Win32 console run(s) done: Fri 13-Oct-23   4:41:58 pm
+! CSE 0.919.0+airnet-msg-control.ec6c303d.4.dirty for Win32 console run(s) done: Thu 19-Oct-23  10:12:56 am
 
 ! Executable:   d:\cse\msvc\cse.exe
-!               13-Oct-23   4:32 pm   (VS 14.29    2796544 bytes)  (HPWH 1.22.0+HEAD.d205413.4)
+!               19-Oct-23  10:10 am   (VS 14.29    2797568 bytes)  (HPWH 1.22.0+HEAD.d205413.4)
 ! Command line: -x!  -t1 ashppkgroom
 ! Input file:   D:\cse\test\ashppkgroom.cse
 ! Report file:  D:\CSE\TEST\ASHPPKGROOM.REP
 
 ! Timing info --
 
-!                Input:  Time = 0.10     Calls = 2         T/C = 0.0490
-!           AutoSizing:  Time = 0.27     Calls = 1         T/C = 0.2690
-!           Simulation:  Time = 6.66     Calls = 1         T/C = 6.6570
+!                Input:  Time = 0.10     Calls = 2         T/C = 0.0480
+!           AutoSizing:  Time = 0.27     Calls = 1         T/C = 0.2700
+!           Simulation:  Time = 6.61     Calls = 1         T/C = 6.6080
 !              Reports:  Time = 0.00     Calls = 1         T/C = 0.0020
-!                Total:  Time = 7.03     Calls = 1         T/C = 7.0340
+!                Total:  Time = 6.99     Calls = 1         T/C = 6.9850

--- a/test/ref/ASHPTEST2.REP
+++ b/test/ref/ASHPTEST2.REP
@@ -3,54 +3,262 @@
 Error Messages for Run 001:
 
 ---------------
-Warning at hour/subhour 12/0 on Fri 10-Jul of simulation:
+Warning at hour/subhour 12/0 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.87 lb/ft2
+---------------
+Warning at hour/subhour 12/1 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/2 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/3 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/4 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/5 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/6 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/7 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/8 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/9 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/10 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/11 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/12 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.84 lb/ft2
+---------------
+Warning at hour/subhour 12/13 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.84 lb/ft2
+---------------
+Warning at hour/subhour 12/14 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.84 lb/ft2
+---------------
+Warning at hour/subhour 12/15 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.84 lb/ft2
+---------------
+Warning at hour/subhour 12/16 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.84 lb/ft2
+---------------
+Warning at hour/subhour 12/17 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.84 lb/ft2
+---------------
+Warning at hour/subhour 12/18 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.83 lb/ft2
+---------------
+Warning at hour/subhour 12/19 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.83 lb/ft2
+---------------
+Warning at hour/subhour 12/20 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.83 lb/ft2
+---------------
+Warning at hour/subhour 12/21 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.83 lb/ft2
+---------------
+Warning at hour/subhour 12/22 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.83 lb/ft2
+---------------
+Warning at hour/subhour 12/23 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.82 lb/ft2
+---------------
+Warning at hour/subhour 12/24 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.82 lb/ft2
+---------------
+Warning at hour/subhour 12/25 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.82 lb/ft2
+---------------
+Warning at hour/subhour 12/26 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.82 lb/ft2
+---------------
+Warning at hour/subhour 12/27 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.82 lb/ft2
+---------------
+Warning at hour/subhour 12/28 on autoSizing 30-Jun iteration 1:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.82 lb/ft2
+---------------
+Warning at hour/subhour 12/29 on autoSizing 30-Jun iteration 1:
   zone 'Conditioned-zn': unreasonable mode 0 pressure 5.81 lb/ft2
 ---------------
-Warning at hour/subhour 12/1 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.80 lb/ft2
+Warning at hour/subhour 12/0 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.91 lb/ft2
 ---------------
-Warning at hour/subhour 12/2 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.80 lb/ft2
+Warning at hour/subhour 12/1 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.89 lb/ft2
 ---------------
-Warning at hour/subhour 12/3 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.80 lb/ft2
+Warning at hour/subhour 12/2 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.89 lb/ft2
 ---------------
-Warning at hour/subhour 12/4 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.80 lb/ft2
+Warning at hour/subhour 12/3 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.89 lb/ft2
 ---------------
-Warning at hour/subhour 12/5 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.80 lb/ft2
+Warning at hour/subhour 12/4 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.89 lb/ft2
 ---------------
-Warning at hour/subhour 12/6 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.79 lb/ft2
+Warning at hour/subhour 12/5 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.89 lb/ft2
 ---------------
-Warning at hour/subhour 12/7 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.79 lb/ft2
+Warning at hour/subhour 12/6 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.89 lb/ft2
 ---------------
-Warning at hour/subhour 12/8 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.79 lb/ft2
+Warning at hour/subhour 12/7 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.88 lb/ft2
 ---------------
-Warning at hour/subhour 12/9 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.79 lb/ft2
+Warning at hour/subhour 12/8 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.88 lb/ft2
 ---------------
-Warning at hour/subhour 12/10 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.79 lb/ft2
+Warning at hour/subhour 12/9 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.88 lb/ft2
 ---------------
-Warning at hour/subhour 12/11 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.78 lb/ft2
+Warning at hour/subhour 12/10 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.88 lb/ft2
 ---------------
-Warning at hour/subhour 12/12 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.78 lb/ft2
+Warning at hour/subhour 12/11 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.87 lb/ft2
 ---------------
-Warning: zone 'Conditioned-zn': total mode 0 pressure warning count = 13
+Warning at hour/subhour 12/12 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.87 lb/ft2
+---------------
+Warning at hour/subhour 12/13 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.86 lb/ft2
+---------------
+Warning at hour/subhour 12/14 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/15 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/16 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/17 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.84 lb/ft2
+---------------
+Warning at hour/subhour 12/18 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.84 lb/ft2
+---------------
+Warning at hour/subhour 12/19 on autoSizing 30-Jun iteration 2:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.83 lb/ft2
+    Skipping further pressure warning messages for this zone/mode.
+---------------
+Warning: 
+  Zone 'Conditioned-zn': 30-Jun autosizing unreasonable pressure warning counts --
+    mode 0 = 90 / mode 1 = 0
+---------------
+Warning at hour/subhour 12/0 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.90 lb/ft2
+---------------
+Warning at hour/subhour 12/1 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.89 lb/ft2
+---------------
+Warning at hour/subhour 12/2 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.89 lb/ft2
+---------------
+Warning at hour/subhour 12/3 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.89 lb/ft2
+---------------
+Warning at hour/subhour 12/4 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.89 lb/ft2
+---------------
+Warning at hour/subhour 12/5 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.88 lb/ft2
+---------------
+Warning at hour/subhour 12/6 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.88 lb/ft2
+---------------
+Warning at hour/subhour 12/7 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.88 lb/ft2
+---------------
+Warning at hour/subhour 12/8 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.88 lb/ft2
+---------------
+Warning at hour/subhour 12/9 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.88 lb/ft2
+---------------
+Warning at hour/subhour 12/10 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.87 lb/ft2
+---------------
+Warning at hour/subhour 12/11 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.87 lb/ft2
+---------------
+Warning at hour/subhour 12/12 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.87 lb/ft2
+---------------
+Warning at hour/subhour 12/13 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.87 lb/ft2
+---------------
+Warning at hour/subhour 12/14 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.87 lb/ft2
+---------------
+Warning at hour/subhour 12/15 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.86 lb/ft2
+---------------
+Warning at hour/subhour 12/16 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.86 lb/ft2
+---------------
+Warning at hour/subhour 12/17 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.86 lb/ft2
+---------------
+Warning at hour/subhour 12/18 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.86 lb/ft2
+---------------
+Warning at hour/subhour 12/19 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.86 lb/ft2
+---------------
+Warning at hour/subhour 12/20 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/21 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/22 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/23 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/24 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.85 lb/ft2
+---------------
+Warning at hour/subhour 12/25 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.84 lb/ft2
+---------------
+Warning at hour/subhour 12/26 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.84 lb/ft2
+---------------
+Warning at hour/subhour 12/27 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.84 lb/ft2
+---------------
+Warning at hour/subhour 12/28 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.84 lb/ft2
+---------------
+Warning at hour/subhour 12/29 on Tue 30-Jun of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.83 lb/ft2
 ---------------
 Info: Zone 'Conditioned-zn': Temp control outcomes
             Miss setpoint (hr)  Avg Excursion (F) Max Excursion (F)  Miss > 1.0 F tol (hr)
     Heating        94.9              -1.03             -2.83              42.6
-    Cooling        73.1               0.61              2.76               9.1
+    Cooling         5.9               0.35              0.82               0.0
 ---------------
 Warning: Zone 'Attic-atc': Condensation occurred in 3079 subhours of run.
-    Total condensation heat = 35.4109 kBtu.
+    Total condensation heat = 35.4108 kBtu.
+---------------
+Warning: 
+  Zone 'Conditioned-zn': Simulation unreasonable pressure warning counts --
+    mode 0 = 30 / mode 1 = 0
 ---------------
 
 
@@ -59,7 +267,7 @@ System Characteristics
 
    CapH  Cap47  Cap17   HSPF  COP47  COP17   AuxH  Cap95   SEER  EER95 SEERnfX EERnfX vfPerTon fanPwrC fanElecC
  ------ ------ ------ ------ ------ ------ ------ ------ ------ ------ ------- ------ -------- ------- --------
-      0  20000  18000   8.70   3.72   2.40  25000  32722  14.00  12.20   17.24  14.93      350   0.580  1888.80
+      0  20000  18000   8.70   3.72   2.40  25000  83513  14.00  12.20   17.24  14.93      350   0.580  4820.57
 
 
 
@@ -71,16 +279,16 @@ Monthly Energy (kBtu + into the zone, except E = Energy Consumed)
   2 56.9 67.4 67.0       1408       1623        433      -1710      -2938     0    -838       2432          0    158      0        0
   3 64.1 68.3 68.0       1759       1665        440      -1484      -2754    13    -605       1404          0     95      0        0
   4 68.5 68.9 68.6       1955       1487        389      -1477      -2216    57    -661        904          0     64      0        0
-  5 79.0 71.3 71.2       2006       1407        363       -900      -1572   289    -960         69        -75     25     26        0
-  6 85.9 74.8 74.8       2093       1306        335       -666       -876   420   -1526          0       -447     58    153        0
-  7 88.3 76.7 76.7       2128       1378        354       -574       -571   392   -1231          0      -1416    142    495        0
-  8 85.9 76.3 76.4       2092       1465        380       -699       -489   427   -1484          0      -1124    116    384        0
-  9 81.8 76.0 76.0       1993       1557        410       -798       -493   432   -1480          0       -915     98    309        0
+  5 79.0 71.3 71.2       2006       1407        363       -900      -1571   289    -960         69        -73     24     22        0
+  6 86.0 74.8 74.8       2093       1306        335       -667       -878   420   -1497          0       -468     54    139        0
+  7 88.7 76.6 76.7       2127       1378        354       -569       -531   394   -1266          0      -1396    126    432        0
+  8 86.2 76.3 76.4       2092       1465        380       -698       -472   427   -1476          0      -1132    105    339        0
+  9 82.0 76.0 76.0       1993       1557        410       -798       -481   432   -1474          0       -926     89    276        0
  10 69.5 70.5 70.5       1842       1739        462      -1135       -628   471   -1864         44          0     26      0        0
  11 56.0 67.7 67.5       1193       1811        486      -1730      -2168     0    -908       1782          0    123      0        0
  12 52.5 67.4 66.9        926       1941        523      -2082      -3364     0   -1233       3776          0    264      0        0
 
- Yr 70.1 71.1 70.9      20253      19292       5090     -15282     -21669  2501  -13964      14403      -3977   1447   1367        0
+ Yr 70.2 71.0 70.9      20252      19292       5090     -15279     -21602  2502  -13954      14403      -3995   1406   1208        0
 
 
 
@@ -92,16 +300,16 @@ Jan 3875.0      0 1120.1 996.38      0      0      0      0 277.68 32.376      0
 Feb 2865.0      0 631.42 811.94      0      0      0      0 158.20 29.243      0      0      0 303.51 640.99 30.559 175.16 36.618      0 47.313      0      0      0      0      0
 Mar 2131.2      0 370.59 360.49      0      0      0  0.574 94.355 32.332      0      0      0 308.63 651.41 33.833 193.66 37.214      0 48.082      0      0      0      0      0
 Apr 1761.8      0 244.73 278.50      0      0      0  3.047 60.546 31.331      0      0      0 272.45 575.41 32.742 187.67 32.871      0 42.472      0      0      0      0      0
-May 1213.3 25.901 17.641 22.942      0      0      0 20.561  4.437 32.376      0      0      0 254.29 537.05 33.833 193.92 30.680      0 39.640      0      0      0      0      0
-Jun 1256.8 153.26      0      0      0      0      0 57.669      0 31.331      0      0      0 234.37 494.97 32.742 187.67 28.277      0 36.535      0      0      0      0      0
-Jul 1738.8 495.16      0      0      0      0      0 142.33      0 32.376      0      0      0 248.23 524.26 33.833 193.92 29.950      0 38.697      0      0      0      0      0
-Aug 1663.6 384.35      0      0      0      0      0 116.40      0 32.376      0      0      0 266.40 562.62 33.833 193.92 32.141      0 41.528      0      0      0      0      0
-Sep 1631.3 308.75      0      0      0      0      0 97.928      0 31.331      0      0      0 287.10 606.34 32.742 187.67 34.639      0 44.755      0      0      0      0      0
+May 1207.9 21.599 17.641 22.942      0      0      0 19.498  4.437 32.376      0      0      0 254.29 537.05 33.833 193.92 30.680      0 39.640      0      0      0      0      0
+Jun 1239.0 139.09      0      0      0      0      0 54.045      0 31.331      0      0      0 234.37 494.97 32.742 187.67 28.277      0 36.535      0      0      0      0      0
+Jul 1659.2 431.93      0      0      0      0      0 125.97      0 32.376      0      0      0 248.23 524.26 33.833 193.92 29.950      0 38.697      0      0      0      0      0
+Aug 1607.1 339.36      0      0      0      0      0 104.90      0 32.376      0      0      0 266.40 562.62 33.833 193.92 32.141      0 41.528      0      0      0      0      0
+Sep 1589.6 275.57      0      0      0      0      0 89.461      0 31.331      0      0      0 287.10 606.34 32.742 187.67 34.639      0 44.755      0      0      0      0      0
 Oct 1411.2      0 13.168 13.902      0      0      0 23.183  3.262 32.376      0      0      0 323.91 684.09 33.833 193.92 39.081      0 50.494      0      0      0      0      0
 Nov 2524.1      0 492.86 503.82      0      0      0      0 122.77 31.375      0      0      0 340.00 718.52 32.742 187.93 41.047      0 53.036      0      0      0      0      0
 Dec 3943.3      0 1089.4 1088.4      0      0      0      0 264.15 32.376      0      0      0 366.30 773.60 33.833 193.92 44.194      0 57.101      0      0      0      0      0
 
-Yr   26015 1367.4 3979.9 4076.3      0      0      0 461.69 985.40 381.20      0      0      0 3565.4 7530.1 398.36 2283.3 430.17      0 555.81      0      0      0      0      0
+Yr   25814 1207.6 3979.9 4076.3      0      0      0 420.67 985.40 381.20      0      0      0 3565.4 7530.1 398.36 2283.3 430.17      0 555.81      0      0      0      0      0
 
 
 
@@ -163,32 +371,32 @@ Energy Balance (F, kBtu, + into the zone) for Tue 30-Jun
 
  Hr Tout  WBo    Wo Tatt  Tin Trad   Win RHin WBin   Slr  Cond  Surf  ItgS  ItgL  AirL sInfVnt ACH Clgs  Clgl  Clgt RunF  FfanE  ClgkE
  -- ---- ---- ----- ---- ---- ---- ----- --- ---- ------ ----- ----- ----- ----- ----- ----- ---- ----- ----- ----- ---- ------ ------
-  1 70.9 63.9 .0111 84.5 77.8 77.6 .0104  51 65.1      0 -1.21 -0.28  1.51  0.40 -0.56 -.016 0.16     0     0     0    0  0.000      0
-  2 68.9 63.1 .0110 81.2 77.6 77.4 .0105  52 65.2      0 -1.44  0.17  1.44  0.39 -0.53 -0.17 0.16     0     0     0    0  0.000      0
-  3 66.7 61.8 .0107 78.0 77.4 77.2 .0106  53 65.2      0 -1.66  0.58  1.39  0.39 -0.47 -0.31 0.16     0     0     0    0  0.000      0
-  4 64.9 61.2 .0107 75.2 77.1 77.0 .0107  54 65.2      0 -1.88  0.91  1.40  0.39 -0.42 -0.44 0.16     0     0     0    0  0.000      0
-  5 64.8 61.1 .0107 72.6 76.9 76.8 .0107  54 65.2      0 -1.98  1.22  1.39  0.38 -0.40 -0.64 0.16     0     0     0    0  0.000      0
-  6 63.0 60.5 .0107 70.2 76.6 76.5 .0108  55 65.3      0 -2.07  1.08  1.77  0.56 -0.56 -0.78 0.16     0     0     0    0  0.000      0
-  7 63.1 60.5 .0107 68.9 75.9 76.2 .0109  57 65.0   2.96 -2.10  6.77  2.19  0.74 -0.35 -9.82 2.30     0     0     0    0   0.09      0
-  8 65.3 61.3 .0107 69.8 75.4 75.9 .0109  58 65.0   5.18 -1.89  2.83  1.98  0.57 -.095 -8.10 2.18     0     0     0    0   0.09      0
-  9 68.5 62.5 .0108 73.9 75.5 75.8 .0109  57 65.1   5.93 -1.62 -0.43  1.52  0.34 -.002 -5.40 1.98     0     0     0    0   0.09      0
- 10 73.9 65.4 .0115 81.0 75.8 75.9 .0110  57 65.3   5.91 -1.14 -4.23  1.26  0.23 -0.68 -1.81 1.62     0     0     0    0   0.09      0
- 11 80.6 67.7 .0116 89.3 76.3 76.2 .0111  56 65.6   5.56 -0.38 -6.85  1.27  0.24 -0.58  0.40 0.59     0     0     0    0   0.03      0
- 12 85.6 69.6 .0119 97.6 76.8 76.5 .0111  56 65.8   4.65  0.31 -7.10  1.25  0.24 -0.31  0.89 0.17     0     0     0    0      0      0
- 13 91.2 70.7 .0115  105 77.2 76.9 .0112  55 66.0   4.07  0.94 -7.61  1.20  0.23 -0.34  1.40 0.18     0     0     0    0      0      0
- 14 92.1 71.0 .0115  112 77.7 77.3 .0112  55 66.3   4.26  1.30 -8.56  1.22  0.24 -0.32  1.78 0.19     0     0     0    0      0      0
- 15 93.4 71.3 .0114  117 78.1 77.8 .0113  54 66.5   4.89  1.37 -9.58  1.31  0.28 -0.35  2.01 0.19     0     0     0    0      0      0
- 16 96.3 71.4 .0108  120 78.7 78.3 .0113  53 66.8   5.64  1.59 -10.9  1.46  0.34 -0.35  2.20 0.19     0     0     0    0      0      0
- 17 97.2 69.2 .0090  120 79.0 78.8 .0110  52 66.3   6.08  1.74 -8.31  1.77  0.47  2.03  2.35 0.20  -3.6  -2.3  -5.9 0.37    0.5    2.1
- 18 97.9 69.5 .0090  118 78.5 78.8 .0099  48 64.6   6.50  1.94  0.66  2.18  0.60  7.11  2.58 0.23 -13.9  -7.4 -21.3 1.00    1.9    7.9
- 19 98.1 69.8 .0092  114 78.2 78.7 .0091  44 63.4   6.11  2.12  1.56  2.72  0.72  5.23  2.47 0.23 -15.0  -5.8 -20.8 1.00    1.9    7.8
- 20 97.9 69.3 .0088  111 78.0 78.6 .0086  42 62.5   4.30  2.07  2.57  3.15  0.82  3.42  2.24 0.23 -14.3  -4.2 -18.6 0.72    1.7    6.9
- 21 96.1 68.8 .0089  107 78.0 78.4 .0084  41 62.2   0.39  1.59  2.10  3.15  0.83  1.38  1.90 0.21  -9.1  -2.2 -11.4 0.45    1.0    4.1
- 22 89.1 70.0 .0114  102 78.0 78.3 .0083  41 62.1      0  1.06  1.02  2.87  0.74  0.55  1.46 0.20  -6.4  -1.5  -7.9 0.29    0.7    2.6
- 23 82.4 66.9 .0106 98.0 78.0 78.2 .0083  41 62.1      0  0.35  0.51  2.29  0.59 -.050  0.98 0.18  -4.1  -1.0  -5.1 0.17    0.4    1.5
- 24 77.5 64.9 .0103 93.7 78.0 78.1 .0084  41 62.2      0 -0.33  0.19  1.79  0.43 -0.33  0.58 0.17  -2.2  -0.5  -2.8 .075    0.2    0.7
+  1 70.9 63.9 .0111 84.8 77.8 77.6 .0106  52 65.3      0 -1.21 -0.29  1.51  0.40 -0.53 -.009 0.16     0     0     0    0  0.000      0
+  2 68.9 63.1 .0110 81.4 77.6 77.4 .0106  53 65.3      0 -1.44  0.17  1.44  0.39 -0.50 -0.16 0.16     0     0     0    0  0.000      0
+  3 66.7 61.8 .0107 78.3 77.4 77.2 .0107  53 65.4      0 -1.66  0.58  1.39  0.39 -0.45 -0.31 0.16     0     0     0    0  0.000      0
+  4 64.9 61.2 .0107 75.4 77.2 77.0 .0108  54 65.4      0 -1.88  0.91  1.40  0.39 -0.40 -0.43 0.16     0     0     0    0  0.000      0
+  5 64.8 61.1 .0107 72.8 76.9 76.8 .0108  55 65.4      0 -1.98  1.22  1.39  0.38 -0.37 -0.63 0.16     0     0     0    0  0.000      0
+  6 63.0 60.5 .0107 70.3 76.6 76.5 .0109  56 65.4      0 -2.07  1.08  1.77  0.56 -0.53 -0.78 0.16     0     0     0    0  0.000      0
+  7 63.1 60.5 .0107 69.0 75.9 76.2 .0109  58 65.1   2.96 -2.10  6.78  2.19  0.74 -.087 -9.83 2.30     0     0     0    0   0.09      0
+  8 65.3 61.3 .0107 69.9 75.5 75.9 .0109  58 65.1   5.18 -1.89  2.84  1.98  0.57 0.054 -8.11 2.18     0     0     0    0   0.09      0
+  9 68.5 62.5 .0108 73.9 75.5 75.8 .0109  57 65.1   5.93 -1.62 -0.43  1.52  0.34 0.084 -5.40 1.98     0     0     0    0   0.09      0
+ 10 73.9 65.4 .0115 81.0 75.8 75.9 .0110  57 65.4   5.91 -1.14 -4.23  1.26  0.23 -0.63 -1.81 1.62     0     0     0    0   0.09      0
+ 11 80.6 67.7 .0116 89.4 76.3 76.2 .0111  57 65.7   5.56 -0.38 -6.84  1.27  0.24 -0.57  0.40 0.59     0     0     0    0   0.03      0
+ 12 85.6 69.6 .0119 92.3 77.9 77.4 .0118  55 67.5   5.00  0.19 -34.3  1.25  0.24 -4.75 27.86 15.8     0     0     0    0      0      0
+ 13 91.2 70.7 .0115  104 78.6 78.1 .0118  56 67.4   4.09  0.78 -7.27  1.20  0.23 -0.22  1.19 0.18     0     0     0    0      0      0
+ 14 92.1 71.0 .0115  111 78.7 78.3 .0119  56 67.5   4.26  1.17 -8.28  1.22  0.24 -0.18  1.62 0.18     0     0     0    0      0      0
+ 15 93.4 71.3 .0114  116 79.1 78.7 .0119  55 67.7   4.89  1.26 -9.33  1.31  0.28 -0.19  1.88 0.19     0     0     0    0      0      0
+ 16 96.3 71.4 .0108  119 79.5 79.1 .0119  55 67.9   5.64  1.48 -10.7  1.46  0.34 -0.18  2.08 0.19     0     0     0    0      0      0
+ 17 97.2 69.2 .0090  119 79.0 79.2 .0110  52 66.3   6.14  1.76 -0.32  1.77  0.47  6.29  2.46 0.22 -11.8  -6.5 -18.3 0.20    1.3    5.5
+ 18 97.9 69.5 .0090  118 78.1 78.8 .0095  46 64.0   6.54  2.02  9.95  2.18  0.60  9.32  2.76 0.24 -23.4  -9.7 -33.1 0.35    2.5   10.4
+ 19 98.1 69.8 .0092  116 78.0 78.7 .0089  43 63.0   6.10  2.13  2.68  2.72  0.72  4.07  2.52 0.23 -16.1  -4.7 -20.9 0.31    1.6    6.7
+ 20 97.9 69.3 .0088  113 78.0 78.6 .0085  42 62.4   4.28  2.06  2.25  3.15  0.82  2.47  2.30 0.22 -14.0  -3.3 -17.3 0.24    1.4    5.6
+ 21 96.1 68.8 .0089  109 78.0 78.5 .0084  41 62.2   0.39  1.58  2.47  3.15  0.83  1.11  2.00 0.21  -9.6  -2.0 -11.6 0.16    0.9    3.7
+ 22 89.1 70.0 .0114  104 78.0 78.3 .0083  41 62.1      0  1.05  1.39  2.87  0.74  0.45  1.54 0.20  -6.9  -1.4  -8.2 0.11    0.6    2.4
+ 23 82.4 66.9 .0106 99.6 78.0 78.2 .0083  41 62.1      0  0.35  0.84  2.29  0.59 -.078  1.04 0.18  -4.5  -0.9  -5.5 .064    0.4    1.5
+ 24 77.5 64.9 .0103 94.9 78.0 78.1 .0084  41 62.2      0 -0.34  0.47  1.79  0.43 -0.32  0.62 0.17  -2.5  -0.6  -3.1 .031    0.2    0.8
 
- Dy                 94.2 77.4 77.4                 72.42  -1.3 -41.7 43.52 11.15 13.03  -4.2 0.51 -68.7 -25.0 -93.7 .075    8.7   33.7
+ Dy                 94.2 77.6 77.6                 72.87  -1.9 -48.3 43.52 11.15 13.85  22.8 1.16 -88.9 -29.1  -118 .031    9.4   36.6
 
 
 
@@ -196,38 +404,38 @@ Energy Balance (F, kBtu, + into the zone) for Fri 10-Jul
 
  Hr Tout  WBo    Wo Tatt  Tin Trad   Win RHin WBin   Slr  Cond  Surf  ItgS  ItgL  AirL sInfVnt ACH Clgs  Clgl  Clgt RunF  FfanE  ClgkE
  -- ---- ---- ----- ---- ---- ---- ----- --- ---- ------ ----- ----- ----- ----- ----- ----- ---- ----- ----- ----- ---- ------ ------
-  1 74.5 62.4 .0093 92.5 78.0 78.1 .0078  38 61.3      0 -0.72  0.99  1.54  0.41 -0.42  0.46 0.17  -2.3  -0.4  -2.7 .065    0.2    0.7
-  2 70.9 61.4 .0095 88.3 78.0 78.0 .0079  38 61.4      0 -1.32  0.51  1.47  0.40 -0.62  0.12 0.16  -0.8  -0.2  -0.9 .010   0.06    0.2
-  3 68.7 60.4 .0093 84.2 78.0 77.9 .0080  39 61.6      0 -1.60  0.32  1.42  0.40 -0.74 -0.12 0.16 -0.02 -.003 -0.02    0  0.001  0.004
-  4 65.8 59.6 .0095 80.4 77.9 77.7 .0081  40 61.7      0 -1.87  0.75  1.43  0.40 -0.72 -0.31 0.16     0     0     0    0  0.000      0
-  5 64.8 58.8 .0093 76.8 77.7 77.6 .0082  41 61.8      0 -2.10  1.13  1.42  0.39 -0.68 -0.46 0.16     0     0     0    0  0.000      0
-  6 63.9 58.6 .0093 73.4 77.5 77.4 .0083  42 61.9      0 -2.20  1.06  1.81  0.57 -0.82 -0.67 0.16     0     0     0    0  0.000      0
-  7 62.6 58.6 .0096 71.0 76.7 77.0 .0089  46 62.3   2.50 -2.27  8.02  2.24  0.76 -3.64 -10.5 2.36     0     0     0    0   0.09      0
-  8 67.8 61.4 .0102 70.8 76.2 76.7 .0093  48 63.1   5.11 -1.91  2.69  2.02  0.58 -2.97 -7.91 2.16     0     0     0    0   0.09      0
-  9 75.7 63.3 .0096 74.8 76.6 76.8 .0095  48 63.6   5.98 -1.22 -3.82  1.56  0.35 -1.33 -2.49 1.52     0     0     0    0   0.09      0
- 10 81.7 65.6 .0099 82.2 77.2 77.1 .0096  47 63.8   6.01 -0.47 -7.15  1.29  0.24 -0.27  0.32 0.33     0     0     0    0   0.02      0
- 11 87.6 67.4 .0098 90.9 77.7 77.5 .0096  47 64.1   5.66  0.25 -7.82  1.29  0.24 -0.26  0.62 0.16     0     0     0    0      0      0
- 12 92.8 71.3 .0116 95.1 80.5 79.6 .0111  47 67.5   5.21  0.76 -58.3  1.28  0.24 -9.82 51.06 15.6     0     0     0    0      0      0
- 13 99.3 73.2 .0117  108 81.3 80.5 .0112  49 67.2   4.07  1.39 -8.11  1.23  0.24 -0.28  1.43 0.19     0     0     0    0      0      0
- 14  103 71.8 .0098  117 81.2 80.6 .0112  49 67.4   4.11  2.01 -9.43  1.25  0.24 -0.22  2.07 0.20     0     0     0    0      0      0
- 15  106 74.5 .0112  123 81.0 80.9 .0108  47 66.7   5.01  2.52 -5.49  1.33  0.29  2.80  2.75 0.22  -6.1  -3.0  -9.1 0.47    0.8    3.7
- 16  107 72.6 .0093  126 80.7 80.9 .0100  45 65.4   5.93  2.85 -0.36  1.49  0.35  5.30  3.34 0.24 -13.2  -5.6 -18.9 1.00    1.9    8.5
- 17  109 73.8 .0099  128 80.6 81.0 .0094  42 64.6   6.33  3.03 -1.26  1.81  0.48  3.87  3.52 0.25 -13.4  -4.3 -17.8 1.00    1.9    8.5
- 18  109 73.8 .0100  127 80.7 81.1 .0089  40 64.0   6.44  3.20 -1.52  2.23  0.62  2.70  3.48 0.25 -13.8  -3.4 -17.3 1.00    1.9    8.6
- 19  108 74.1 .0104  123 80.7 81.2 .0087  39 63.6   5.85  3.24 -0.51  2.78  0.73  1.92  3.21 0.24 -14.6  -2.9 -17.5 1.00    1.9    8.5
- 20  107 74.5 .0110  119 80.6 81.1 .0084  38 63.2   3.74  3.13  2.43  3.22  0.84  1.34  2.89 0.25 -15.4  -2.6 -18.0 1.00    1.9    8.4
- 21  102 72.4 .0104  113 80.2 80.8 .0083  38 62.7   0.19  2.57  7.96  3.23  0.85  1.25  2.48 0.24 -16.4  -2.7 -19.1 1.00    1.9    8.2
- 22 94.1 70.4 .0106  107 79.6 80.2 .0080  38 62.0      0  1.73 11.25  2.94  0.76  1.64  1.93 0.23 -17.8  -2.9 -20.7 1.00    1.9    7.7
- 23 87.4 66.9 .0095  101 78.8 79.6 .0077  37 61.3      0  0.84 14.75  2.34  0.60  2.04  1.41 0.21 -19.3  -3.1 -22.5 1.00    1.9    7.2
- 24 83.5 65.3 .0093 96.1 78.1 78.9 .0075  37 60.8      0  0.24 12.17  1.83  0.44  1.48  0.98 0.20 -15.2  -2.3 -17.5 0.48    1.4    5.2
+  1 74.5 62.4 .0093 94.5 78.0 78.1 .0079  39 61.5      0 -0.71  0.89  1.54  0.41 -0.42  0.51 0.17  -2.2  -0.4  -2.6 .023    0.2    0.6
+  2 70.9 61.4 .0095 89.9 78.0 78.0 .0080  39 61.6      0 -1.32  0.46  1.47  0.40 -0.60  0.16 0.16  -0.8  -0.2  -0.9 .004   0.06    0.2
+  3 68.7 60.4 .0093 85.5 78.0 77.9 .0081  40 61.8      0 -1.60  0.29  1.42  0.40 -0.71 -.089 0.16 -0.02 -.004 -0.02    0  0.001  0.004
+  4 65.8 59.6 .0095 81.4 77.9 77.7 .0082  40 61.9      0 -1.87  0.73  1.43  0.40 -0.69 -0.29 0.16     0     0     0    0  0.000      0
+  5 64.8 58.8 .0093 77.7 77.7 77.6 .0083  41 61.9      0 -2.10  1.12  1.42  0.39 -0.65 -0.44 0.16     0     0     0    0  0.000      0
+  6 63.9 58.6 .0093 74.2 77.5 77.4 .0084  42 62.1      0 -2.20  1.02  1.81  0.57 -0.80 -0.64 0.16     0     0     0    0  0.000      0
+  7 62.6 58.6 .0096 71.5 76.7 77.0 .0090  46 62.5   2.50 -2.27  8.00  2.24  0.76 -3.34 -10.5 2.36     0     0     0    0   0.09      0
+  8 67.8 61.4 .0102 71.2 76.2 76.7 .0094  48 63.1   5.11 -1.91  2.67  2.02  0.58 -2.81 -7.89 2.17     0     0     0    0   0.09      0
+  9 75.7 63.3 .0096 75.1 76.6 76.8 .0096  48 63.6   5.98 -1.22 -3.84  1.56  0.35 -1.26 -2.47 1.52     0     0     0    0   0.09      0
+ 10 81.7 65.6 .0099 82.5 77.2 77.1 .0096  48 63.9   6.01 -0.47 -7.17  1.29  0.24 -0.26  0.34 0.33     0     0     0    0   0.02      0
+ 11 87.6 67.4 .0098 91.2 77.7 77.5 .0096  47 64.1   5.66  0.25 -7.83  1.29  0.24 -0.26  0.62 0.16     0     0     0    0      0      0
+ 12 92.8 71.3 .0116  100 78.2 77.9 .0097  47 64.3   4.86  0.95 -8.26  1.28  0.24 -0.34  1.17 0.18     0     0     0    0      0      0
+ 13 99.3 73.2 .0117  109 78.7 78.3 .0098  46 64.6   4.04  1.68 -8.71  1.23  0.24 -0.51  1.76 0.19     0     0     0    0      0      0
+ 14  103 71.8 .0098  118 79.2 78.8 .0099  46 64.9   4.11  2.25 -9.95  1.25  0.24 -0.52  2.34 0.20     0     0     0    0      0      0
+ 15  106 74.5 .0112  125 79.9 79.4 .0099  45 65.2   4.93  2.62 -11.7  1.33  0.29 -0.49  2.83 0.21     0     0     0    0      0      0
+ 16  107 72.6 .0093  129 80.0 79.9 .0097  44 64.8   5.84  2.87 -6.52  1.49  0.35  1.47  3.35 0.23  -7.0  -2.0  -9.0 0.18    0.8    3.4
+ 17  109 73.8 .0099  130 79.1 79.6 .0089  42 63.3   6.36  3.26  7.70  1.81  0.48  5.22  4.02 0.26 -23.1  -5.8 -29.0 0.41    2.6   11.6
+ 18  109 73.8 .0100  128 78.1 79.0 .0081  40 61.8   6.51  3.65 16.36  2.23  0.62  5.21  4.32 0.28 -33.1  -6.1 -39.2 0.55    3.6   16.3
+ 19  108 74.1 .0104  125 78.0 78.8 .0078  38 61.3   5.88  3.66  7.33  2.78  0.73  1.93  3.81 0.26 -23.5  -3.1 -26.5 0.46    2.5   11.0
+ 20  107 74.5 .0110  121 78.0 78.8 .0077  38 61.2   3.75  3.50  5.88  3.22  0.84  0.73  3.36 0.25 -19.7  -2.2 -21.9 0.36    2.0    8.9
+ 21  102 72.4 .0104  116 78.0 78.6 .0077  38 61.2   0.19  2.83  5.20  3.23  0.85 .0088  2.79 0.24 -14.2  -1.6 -15.8 0.25    1.4    6.0
+ 22 94.1 70.4 .0106  111 78.0 78.5 .0077  38 61.2      0  1.89  3.73  2.94  0.76 -.066  2.15 0.21 -10.7  -1.3 -12.0 0.17    1.0    4.0
+ 23 87.4 66.9 .0095  106 78.0 78.4 .0077  38 61.2      0  0.91  2.79  2.34  0.60 -.079  1.54 0.19  -7.6  -1.1  -8.6 0.11    0.7    2.5
+ 24 83.5 65.3 .0093  100 78.0 78.3 .0077  38 61.2      0  0.26  2.07  1.83  0.44 -.064  1.07 0.18  -5.2  -0.8  -6.0 .076    0.4    1.6
 
- Dy                 98.7 79.0 79.1                 72.13  12.1 -39.8 44.45 11.43  1.56  59.6 1.08  -149 -33.5  -182 0.48   17.9   75.4
+ Dy                  101 78.0 78.2                 71.72  14.9   2.2 44.45 11.43  0.69  13.9 0.43  -147 -24.5  -172 .076   15.5   66.2
 
 
 
 ! Log for Run 001:
 
-! CSE 0.919.0+airnet-msg-control.c2cc5738.2 for Win32 console
+! CSE 0.919.0+airnet-msg-control.1a648c61.3.dirty for Win32 console
 
 
 
@@ -909,7 +1117,7 @@ Input for Run 001:
         IZXFER   "Conditioned-IAQFanE"  
            izNVType = "AIRNETEXTFAN"
            izZn1 = "Conditioned-zn"
-           izVFmin = $dayOfYear==jul 10 && $hour==12 ? 5000 : -51
+           izVFmin = $dayOfYear==Jun 30 && $hour==12 ? 5000 : -51
            izVFmax = -51
            izFanVfDs = 51
            izFanElecPwr = 0.25
@@ -1794,18 +2002,18 @@ Input for Run 001:
 
 
 
-! CSE 0.919.0+airnet-msg-control.c2cc5738.2 for Win32 console run(s) done: Mon 16-Oct-23   1:17:34 pm
+! CSE 0.919.0+airnet-msg-control.1a648c61.3.dirty for Win32 console run(s) done: Wed 18-Oct-23   9:03:00 am
 
 ! Executable:   d:\cse\msvc\cse.exe
-!               16-Oct-23   1:02 pm   (VS 14.29    2796544 bytes)  (HPWH 1.22.0+HEAD.d205413.4)
+!               18-Oct-23   8:58 am   (VS 14.29    2797568 bytes)  (HPWH 1.22.0+HEAD.d205413.4)
 ! Command line: -x!  -t1 ashptest2
 ! Input file:   D:\cse\test\ashptest2.cse
 ! Report file:  D:\CSE\TEST\ASHPTEST2.REP
 
 ! Timing info --
 
-!                Input:  Time = 0.10     Calls = 2         T/C = 0.0505
-!           AutoSizing:  Time = 1.14     Calls = 1         T/C = 1.1380
-!           Simulation:  Time = 12.55    Calls = 1         T/C = 12.5530
+!                Input:  Time = 0.10     Calls = 2         T/C = 0.0485
+!           AutoSizing:  Time = 1.66     Calls = 1         T/C = 1.6630
+!           Simulation:  Time = 13.21    Calls = 1         T/C = 13.2050
 !              Reports:  Time = 0.02     Calls = 1         T/C = 0.0190
-!                Total:  Time = 13.81    Calls = 1         T/C = 13.8150
+!                Total:  Time = 14.99    Calls = 1         T/C = 14.9860

--- a/test/ref/ASHPTEST2.REP
+++ b/test/ref/ASHPTEST2.REP
@@ -3,10 +3,102 @@
 Error Messages for Run 001:
 
 ---------------
+Warning at hour/subhour 12/0 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.81 lb/ft2
+---------------
+Warning at hour/subhour 12/1 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.80 lb/ft2
+---------------
+Warning at hour/subhour 12/2 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.80 lb/ft2
+---------------
+Warning at hour/subhour 12/3 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.80 lb/ft2
+---------------
+Warning at hour/subhour 12/4 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.80 lb/ft2
+---------------
+Warning at hour/subhour 12/5 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.80 lb/ft2
+---------------
+Warning at hour/subhour 12/6 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.79 lb/ft2
+---------------
+Warning at hour/subhour 12/7 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.79 lb/ft2
+---------------
+Warning at hour/subhour 12/8 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.79 lb/ft2
+---------------
+Warning at hour/subhour 12/9 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.79 lb/ft2
+---------------
+Warning at hour/subhour 12/10 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.79 lb/ft2
+---------------
+Warning at hour/subhour 12/11 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.78 lb/ft2
+---------------
+Warning at hour/subhour 12/12 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.78 lb/ft2
+---------------
+Warning at hour/subhour 12/13 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.78 lb/ft2
+---------------
+Warning at hour/subhour 12/14 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.78 lb/ft2
+---------------
+Warning at hour/subhour 12/15 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.78 lb/ft2
+---------------
+Warning at hour/subhour 12/16 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.77 lb/ft2
+---------------
+Warning at hour/subhour 12/17 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.77 lb/ft2
+---------------
+Warning at hour/subhour 12/18 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.77 lb/ft2
+---------------
+Warning at hour/subhour 12/19 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.77 lb/ft2
+---------------
+Warning at hour/subhour 12/20 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.77 lb/ft2
+---------------
+Warning at hour/subhour 12/21 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.76 lb/ft2
+---------------
+Warning at hour/subhour 12/22 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.76 lb/ft2
+---------------
+Warning at hour/subhour 12/23 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.76 lb/ft2
+---------------
+Warning at hour/subhour 12/24 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.76 lb/ft2
+---------------
+Warning at hour/subhour 12/25 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.76 lb/ft2
+---------------
+Warning at hour/subhour 12/26 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.75 lb/ft2
+---------------
+Warning at hour/subhour 12/27 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.75 lb/ft2
+---------------
+Warning at hour/subhour 12/28 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.75 lb/ft2
+---------------
+Warning at hour/subhour 12/29 on Fri 10-Jul of simulation:
+  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.75 lb/ft2
+---------------
+Warning: zone 'Conditioned-zn': total mode 0 pressure warning count = 30
+---------------
 Info: Zone 'Conditioned-zn': Temp control outcomes
             Miss setpoint (hr)  Avg Excursion (F) Max Excursion (F)  Miss > 1.0 F tol (hr)
     Heating        94.9              -1.03             -2.83              42.6
-    Cooling        71.1               0.54              1.94               6.9
+    Cooling        73.1               0.61              2.76               9.1
 ---------------
 Warning: Zone 'Attic-atc': Condensation occurred in 3079 subhours of run.
     Total condensation heat = 35.4109 kBtu.
@@ -32,14 +124,14 @@ Monthly Energy (kBtu + into the zone, except E = Energy Consumed)
   4 68.5 68.9 68.6       1955       1487        389      -1477      -2216    57    -661        904          0     64      0        0
   5 79.0 71.3 71.2       2006       1407        363       -900      -1572   289    -960         69        -75     25     26        0
   6 85.9 74.8 74.8       2093       1306        335       -666       -876   420   -1526          0       -447     58    153        0
-  7 88.3 76.7 76.7       2127       1378        354       -572       -562   393   -1278          0      -1370    139    480        0
+  7 88.3 76.7 76.7       2128       1378        354       -574       -571   392   -1231          0      -1416    142    495        0
   8 85.9 76.3 76.4       2092       1465        380       -699       -489   427   -1484          0      -1124    116    384        0
   9 81.8 76.0 76.0       1993       1557        410       -798       -493   432   -1480          0       -915     98    309        0
  10 69.5 70.5 70.5       1842       1739        462      -1135       -628   471   -1864         44          0     26      0        0
  11 56.0 67.7 67.5       1193       1811        486      -1730      -2168     0    -908       1782          0    123      0        0
  12 52.5 67.4 66.9        926       1941        523      -2082      -3364     0   -1233       3776          0    264      0        0
 
- Yr 70.1 71.1 70.9      20253      19292       5090     -15280     -21660  2502  -14011      14403      -3931   1443   1352        0
+ Yr 70.1 71.1 70.9      20253      19292       5090     -15282     -21669  2501  -13964      14403      -3977   1447   1367        0
 
 
 
@@ -53,14 +145,14 @@ Mar 2131.2      0 370.59 360.49      0      0      0  0.574 94.355 32.332      0
 Apr 1761.8      0 244.73 278.50      0      0      0  3.047 60.546 31.331      0      0      0 272.45 575.41 32.742 187.67 32.871      0 42.472      0      0      0      0      0
 May 1213.3 25.901 17.641 22.942      0      0      0 20.561  4.437 32.376      0      0      0 254.29 537.05 33.833 193.92 30.680      0 39.640      0      0      0      0      0
 Jun 1256.8 153.26      0      0      0      0      0 57.669      0 31.331      0      0      0 234.37 494.97 32.742 187.67 28.277      0 36.535      0      0      0      0      0
-Jul 1719.8 479.92      0      0      0      0      0 138.62      0 32.376      0      0      0 248.23 524.26 33.833 193.92 29.950      0 38.697      0      0      0      0      0
-Aug 1663.5 384.29      0      0      0      0      0 116.38      0 32.376      0      0      0 266.40 562.62 33.833 193.92 32.141      0 41.528      0      0      0      0      0
+Jul 1738.8 495.16      0      0      0      0      0 142.33      0 32.376      0      0      0 248.23 524.26 33.833 193.92 29.950      0 38.697      0      0      0      0      0
+Aug 1663.6 384.35      0      0      0      0      0 116.40      0 32.376      0      0      0 266.40 562.62 33.833 193.92 32.141      0 41.528      0      0      0      0      0
 Sep 1631.3 308.75      0      0      0      0      0 97.928      0 31.331      0      0      0 287.10 606.34 32.742 187.67 34.639      0 44.755      0      0      0      0      0
 Oct 1411.2      0 13.168 13.902      0      0      0 23.183  3.262 32.376      0      0      0 323.91 684.09 33.833 193.92 39.081      0 50.494      0      0      0      0      0
 Nov 2524.1      0 492.86 503.82      0      0      0      0 122.77 31.375      0      0      0 340.00 718.52 32.742 187.93 41.047      0 53.036      0      0      0      0      0
 Dec 3943.3      0 1089.4 1088.4      0      0      0      0 264.15 32.376      0      0      0 366.30 773.60 33.833 193.92 44.194      0 57.101      0      0      0      0      0
 
-Yr   25996 1352.1 3979.9 4076.3      0      0      0 457.97 985.40 381.20      0      0      0 3565.4 7530.1 398.36 2283.3 430.17      0 555.81      0      0      0      0      0
+Yr   26015 1367.4 3979.9 4076.3      0      0      0 461.69 985.40 381.20      0      0      0 3565.4 7530.1 398.36 2283.3 430.17      0 555.81      0      0      0      0      0
 
 
 
@@ -166,27 +258,27 @@ Energy Balance (F, kBtu, + into the zone) for Fri 10-Jul
   9 75.7 63.3 .0096 74.8 76.6 76.8 .0095  48 63.6   5.98 -1.22 -3.82  1.56  0.35 -1.33 -2.49 1.52     0     0     0    0   0.09      0
  10 81.7 65.6 .0099 82.2 77.2 77.1 .0096  47 63.8   6.01 -0.47 -7.15  1.29  0.24 -0.27  0.32 0.33     0     0     0    0   0.02      0
  11 87.6 67.4 .0098 90.9 77.7 77.5 .0096  47 64.1   5.66  0.25 -7.82  1.29  0.24 -0.26  0.62 0.16     0     0     0    0      0      0
- 12 92.8 71.3 .0116  100 78.2 77.9 .0097  46 64.3   4.86  0.95 -8.25  1.28  0.24 -0.34  1.16 0.18     0     0     0    0      0      0
- 13 99.3 73.2 .0117  109 78.7 78.3 .0097  46 64.6   4.04  1.68 -8.70  1.23  0.24 -0.52  1.75 0.19     0     0     0    0      0      0
- 14  103 71.8 .0098  117 79.2 78.8 .0098  46 64.9   4.11  2.25 -9.94  1.25  0.24 -0.53  2.33 0.20     0     0     0    0      0      0
- 15  106 74.5 .0112  125 79.9 79.4 .0099  45 65.2   4.93  2.62 -11.7  1.33  0.29 -0.50  2.82 0.21     0     0     0    0      0      0
- 16  107 72.6 .0093  129 80.0 79.9 .0096  44 64.7   5.86  2.89 -6.71  1.49  0.35  1.85  3.35 0.23  -6.9  -2.4  -9.3 0.59    1.0    4.3
- 17  109 73.8 .0099  129 79.8 80.1 .0091  42 63.9   6.32  3.14 -1.94  1.81  0.48  3.43  3.70 0.25 -13.0  -4.0 -17.0 1.00    1.9    8.5
- 18  109 73.8 .0100  128 79.8 80.2 .0087  40 63.4   6.44  3.32 -2.22  2.23  0.62  2.45  3.66 0.25 -13.4  -3.2 -16.7 1.00    1.9    8.5
- 19  108 74.1 .0104  124 79.9 80.4 .0085  39 63.0   5.85  3.36 -1.14  2.78  0.73  1.74  3.35 0.25 -14.2  -2.8 -17.0 1.00    1.9    8.5
- 20  107 74.5 .0110  119 79.9 80.4 .0083  38 62.6   3.74  3.24  1.87  3.22  0.84  1.19  3.01 0.25 -15.1  -2.5 -17.6 1.00    1.9    8.4
- 21  102 72.4 .0104  113 79.5 80.0 .0081  38 62.2   0.19  2.67  7.47  3.23  0.85  1.11  2.57 0.24 -16.1  -2.6 -18.7 1.00    1.9    8.1
- 22 94.1 70.4 .0106  107 78.9 79.5 .0079  38 61.6      0  1.82 10.81  2.94  0.76  1.51  2.01 0.23 -17.6  -2.8 -20.4 1.00    1.9    7.7
- 23 87.4 66.9 .0095  102 78.2 78.9 .0076  37 61.0      0  0.92 12.12  2.34  0.60  1.59  1.46 0.21 -16.8  -2.7 -19.5 0.59    1.7    6.4
- 24 83.5 65.3 .0093 97.0 78.0 78.6 .0075  37 60.9      0  0.25  5.81  1.83  0.44  0.54  0.96 0.19  -8.9  -1.4 -10.2 0.34    0.8    3.0
+ 12 92.8 71.3 .0116 95.1 80.5 79.6 .0111  47 67.5   5.21  0.76 -58.3  1.28  0.24 -9.82 51.06 15.6     0     0     0    0      0      0
+ 13 99.3 73.2 .0117  108 81.3 80.5 .0112  49 67.2   4.07  1.39 -8.11  1.23  0.24 -0.28  1.43 0.19     0     0     0    0      0      0
+ 14  103 71.8 .0098  117 81.2 80.6 .0112  49 67.4   4.11  2.01 -9.43  1.25  0.24 -0.22  2.07 0.20     0     0     0    0      0      0
+ 15  106 74.5 .0112  123 81.0 80.9 .0108  47 66.7   5.01  2.52 -5.49  1.33  0.29  2.80  2.75 0.22  -6.1  -3.0  -9.1 0.47    0.8    3.7
+ 16  107 72.6 .0093  126 80.7 80.9 .0100  45 65.4   5.93  2.85 -0.36  1.49  0.35  5.30  3.34 0.24 -13.2  -5.6 -18.9 1.00    1.9    8.5
+ 17  109 73.8 .0099  128 80.6 81.0 .0094  42 64.6   6.33  3.03 -1.26  1.81  0.48  3.87  3.52 0.25 -13.4  -4.3 -17.8 1.00    1.9    8.5
+ 18  109 73.8 .0100  127 80.7 81.1 .0089  40 64.0   6.44  3.20 -1.52  2.23  0.62  2.70  3.48 0.25 -13.8  -3.4 -17.3 1.00    1.9    8.6
+ 19  108 74.1 .0104  123 80.7 81.2 .0087  39 63.6   5.85  3.24 -0.51  2.78  0.73  1.92  3.21 0.24 -14.6  -2.9 -17.5 1.00    1.9    8.5
+ 20  107 74.5 .0110  119 80.6 81.1 .0084  38 63.2   3.74  3.13  2.43  3.22  0.84  1.34  2.89 0.25 -15.4  -2.6 -18.0 1.00    1.9    8.4
+ 21  102 72.4 .0104  113 80.2 80.8 .0083  38 62.7   0.19  2.57  7.96  3.23  0.85  1.25  2.48 0.24 -16.4  -2.7 -19.1 1.00    1.9    8.2
+ 22 94.1 70.4 .0106  107 79.6 80.2 .0080  38 62.0      0  1.73 11.25  2.94  0.76  1.64  1.93 0.23 -17.8  -2.9 -20.7 1.00    1.9    7.7
+ 23 87.4 66.9 .0095  101 78.8 79.6 .0077  37 61.3      0  0.84 14.75  2.34  0.60  2.04  1.41 0.21 -19.3  -3.1 -22.5 1.00    1.9    7.2
+ 24 83.5 65.3 .0093 96.1 78.1 78.9 .0075  37 60.8      0  0.24 12.17  1.83  0.44  1.48  0.98 0.20 -15.2  -2.3 -17.5 0.48    1.4    5.2
 
- Dy                 99.4 78.4 78.5                 71.59  13.7 -15.9 44.45 11.43  1.05  11.2 0.43  -125 -25.0  -150 0.34   15.3   64.4
+ Dy                 98.7 79.0 79.1                 72.13  12.1 -39.8 44.45 11.43  1.56  59.6 1.08  -149 -33.5  -182 0.48   17.9   75.4
 
 
 
 ! Log for Run 001:
 
-! CSE 0.905.0+hiratio.c0620c67.16.dirty for Win32 console
+! CSE 0.919.0+airnet-msg-control.3d9165d5.1.dirty for Win32 console
 
 
 
@@ -866,7 +958,7 @@ Input for Run 001:
         IZXFER   "Conditioned-IAQFanE"  
            izNVType = "AIRNETEXTFAN"
            izZn1 = "Conditioned-zn"
-           izVFmin = -51
+           izVFmin = $dayOfYear==jul 10 && $hour==12 ? 5000 : -51
            izVFmax = -51
            izFanVfDs = 51
            izFanElecPwr = 0.25
@@ -1751,18 +1843,18 @@ Input for Run 001:
 
 
 
-! CSE 0.905.0+hiratio.c0620c67.16.dirty for Win32 console run(s) done: Wed 04-May-22   4:44:25 pm
+! CSE 0.919.0+airnet-msg-control.3d9165d5.1.dirty for Win32 console run(s) done: Mon 16-Oct-23  12:51:09 pm
 
 ! Executable:   d:\cse\msvc\cse.exe
-!               04-May-22   4:42 pm   (VS 14.29    2996736 bytes)  (HPWH 1.18.1)
-! Command line: -x!  -b -t1 ashptest2
+!               16-Oct-23  12:37 pm   (VS 14.29    2796544 bytes)  (HPWH 1.22.0+HEAD.d205413.4)
+! Command line: -x!  -t1 ashptest2
 ! Input file:   D:\cse\test\ashptest2.cse
-! Report file:  D:\cse\test\ashptest2.rep
+! Report file:  D:\CSE\TEST\ASHPTEST2.REP
 
 ! Timing info --
 
-!                Input:  Time = 0.11     Calls = 2      T/C = 0.0535
-!           AutoSizing:  Time = 1.35     Calls = 1      T/C = 1.3550
-!           Simulation:  Time = 14.57    Calls = 1      T/C = 14.5700
-!              Reports:  Time = 0.02     Calls = 1      T/C = 0.0190
-!                Total:  Time = 16.05    Calls = 1      T/C = 16.0520
+!                Input:  Time = 0.09     Calls = 2         T/C = 0.0470
+!           AutoSizing:  Time = 1.12     Calls = 1         T/C = 1.1250
+!           Simulation:  Time = 12.42    Calls = 1         T/C = 12.4180
+!              Reports:  Time = 0.02     Calls = 1         T/C = 0.0180
+!                Total:  Time = 13.66    Calls = 1         T/C = 13.6610

--- a/test/ref/ASHPTEST2.REP
+++ b/test/ref/ASHPTEST2.REP
@@ -42,58 +42,7 @@ Warning at hour/subhour 12/11 on Fri 10-Jul of simulation:
 Warning at hour/subhour 12/12 on Fri 10-Jul of simulation:
   zone 'Conditioned-zn': unreasonable mode 0 pressure 5.78 lb/ft2
 ---------------
-Warning at hour/subhour 12/13 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.78 lb/ft2
----------------
-Warning at hour/subhour 12/14 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.78 lb/ft2
----------------
-Warning at hour/subhour 12/15 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.78 lb/ft2
----------------
-Warning at hour/subhour 12/16 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.77 lb/ft2
----------------
-Warning at hour/subhour 12/17 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.77 lb/ft2
----------------
-Warning at hour/subhour 12/18 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.77 lb/ft2
----------------
-Warning at hour/subhour 12/19 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.77 lb/ft2
----------------
-Warning at hour/subhour 12/20 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.77 lb/ft2
----------------
-Warning at hour/subhour 12/21 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.76 lb/ft2
----------------
-Warning at hour/subhour 12/22 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.76 lb/ft2
----------------
-Warning at hour/subhour 12/23 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.76 lb/ft2
----------------
-Warning at hour/subhour 12/24 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.76 lb/ft2
----------------
-Warning at hour/subhour 12/25 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.76 lb/ft2
----------------
-Warning at hour/subhour 12/26 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.75 lb/ft2
----------------
-Warning at hour/subhour 12/27 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.75 lb/ft2
----------------
-Warning at hour/subhour 12/28 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.75 lb/ft2
----------------
-Warning at hour/subhour 12/29 on Fri 10-Jul of simulation:
-  zone 'Conditioned-zn': unreasonable mode 0 pressure 5.75 lb/ft2
----------------
-Warning: zone 'Conditioned-zn': total mode 0 pressure warning count = 30
+Warning: zone 'Conditioned-zn': total mode 0 pressure warning count = 13
 ---------------
 Info: Zone 'Conditioned-zn': Temp control outcomes
             Miss setpoint (hr)  Avg Excursion (F) Max Excursion (F)  Miss > 1.0 F tol (hr)
@@ -278,7 +227,7 @@ Energy Balance (F, kBtu, + into the zone) for Fri 10-Jul
 
 ! Log for Run 001:
 
-! CSE 0.919.0+airnet-msg-control.3d9165d5.1.dirty for Win32 console
+! CSE 0.919.0+airnet-msg-control.c2cc5738.2 for Win32 console
 
 
 
@@ -303,6 +252,8 @@ Input for Run 001:
            dt = "YES"
            heatDsTDbO = 37
            coolDsDay = DD1
+           ANPressWarn = 5.78   // airnet pressure warning threshold
+                                //   triggers a few warnings for testing
         
         MATERIAL   "mat-Gypsum Board"  
            matDens = 40
@@ -1843,18 +1794,18 @@ Input for Run 001:
 
 
 
-! CSE 0.919.0+airnet-msg-control.3d9165d5.1.dirty for Win32 console run(s) done: Mon 16-Oct-23  12:51:09 pm
+! CSE 0.919.0+airnet-msg-control.c2cc5738.2 for Win32 console run(s) done: Mon 16-Oct-23   1:17:34 pm
 
 ! Executable:   d:\cse\msvc\cse.exe
-!               16-Oct-23  12:37 pm   (VS 14.29    2796544 bytes)  (HPWH 1.22.0+HEAD.d205413.4)
+!               16-Oct-23   1:02 pm   (VS 14.29    2796544 bytes)  (HPWH 1.22.0+HEAD.d205413.4)
 ! Command line: -x!  -t1 ashptest2
 ! Input file:   D:\cse\test\ashptest2.cse
 ! Report file:  D:\CSE\TEST\ASHPTEST2.REP
 
 ! Timing info --
 
-!                Input:  Time = 0.09     Calls = 2         T/C = 0.0470
-!           AutoSizing:  Time = 1.12     Calls = 1         T/C = 1.1250
-!           Simulation:  Time = 12.42    Calls = 1         T/C = 12.4180
-!              Reports:  Time = 0.02     Calls = 1         T/C = 0.0180
-!                Total:  Time = 13.66    Calls = 1         T/C = 13.6610
+!                Input:  Time = 0.10     Calls = 2         T/C = 0.0505
+!           AutoSizing:  Time = 1.14     Calls = 1         T/C = 1.1380
+!           Simulation:  Time = 12.55    Calls = 1         T/C = 12.5530
+!              Reports:  Time = 0.02     Calls = 1         T/C = 0.0190
+!                Total:  Time = 13.81    Calls = 1         T/C = 13.8150


### PR DESCRIPTION
## Description

Motivation: improve user control of AirNet errors and warnings.

Added two inputs: Top.ANPressWarn (default = 5 lb/ft2) and Top.ANPressErr (default = 30 lb/ft2) which set the pressure thresholds for warning and errors triggered by unreasonable pressure results during AirNet calcs.

With this change, pressures above ANPressErr terminate simulation immediately.

Pressures greater than ANPressWarn trigger warning messages.  A limited number (currently 50 per zone) are displayed.  Any additional warnings are counted (not displayed).  A total warning count is display at the end of the run.  Warnings never cause run termination.

Added documentation for new inputs.

Altered test case ASHPTest2 to produce a few warnings.

No results changes for pre-existing cases except when zone pressures exceed default levels.
