### PR TITLE
Bug fix: prevent crash due to autosized DHWHEATER tank volume = 0

### DIFF
--- a/src/dhwcalc.cpp
+++ b/src/dhwcalc.cpp
@@ -664,7 +664,7 @@ RC DHWSIZER::wz_DeriveSize()	// calc required heating and storage volume
 	// required volume (based on setpoint, not use temp)
 	// 	 tank volume is derived from running volume in HPWHLINK::hw_DeriveVolFromVolRunning()
 	//   (applies aquastat fraction etc.)
-	float volRunning = -qRunning / (waterRhoCp * (pWS->ws_tSetpointDes - pWS->ws_tInletDes));
+	float volRunning = max(10.f, -qRunning / (waterRhoCp * (pWS->ws_tSetpointDes - pWS->ws_tInletDes)));
 
 	pWS->ws_ApplySizingResults(heatingCapDes, heatingCapTopN, volRunning);
 
@@ -3415,7 +3415,7 @@ RC HPWHLINK::hw_DeriveVolFromVolRunning(		// calc required volume from running v
 
 	// total volume req'd based on minimum run time (avoid short cycle)
 	//   Determine vol of water heated in minimum compressor cycle.
-	//   Usable volume below aquastat must be >= to
+	//   Usable volume below aquastat must be >= to this vol
 	float runHrMin = hw_pHPWH->getCompressorMinRuntime( HPWH::UNITS_HR);		// minimum compressor run time, hr
 	float volCycMin = heatingCap * runHrMin / (waterRhoCp * max(tempRise, 10.f));
 	float totVolCyc = volCycMin / (aquaFract - unuseableFract);


### PR DESCRIPTION
Very small DHW loads could cause derived DHWHEATER tank size to be 0.  However, a non-0 tank size is required, so runs encountering this case terminated.

Added code that limits the derived volume to a minimum of 10 gal.

Retested offending case (from user) -- now runs.

No regression test changes.

No documentation changes.