### PR TITLE
Bug fix: Change DHWLOOP deltaT limit to 0 F (was 1 F)

### DIFF
--- a/src/dhwcalc.cpp
+++ b/src/dhwcalc.cpp
@@ -4890,7 +4890,7 @@ RC DHWHEATER::wh_DoSubhrTick(		// DHWHEATER energy use for 1 tick
 			rc |= wh_InstUEFDoSubhrTick(drawForTick, tInletMix, scaleWH, pWS->ws_tUse);
 
 		else
-		{	float deltaT = max(1.f, pWS->ws_tUse - tInletMix);
+		{	float deltaT = max(0.f, pWS->ws_tUse - tInletMix);
 
 			float HARL = drawForTick * waterRhoCp * deltaT;		// load on this heater, Btu
 


### PR DESCRIPTION
## Description

In DHWSYS configurations with DHWLOOPs with minimal losses, it is possible to have small or no temperature drop across the loop.  When there are no other draws, the water heater inlet temp thus be the same as the outlet.  The code formerly limited the possible delta-T to 1 F and reduced the inlet temp to enforce that.  When the inlet temp was changed in this fashion, an artificial load was created.  Energy balance errors resulted.

Fix: changed the delta-T limit to 0 F.

Note that this does not address the case where the loop return temp is higher than the water heater outlet temp.  That can occur when segment surround temperatures are high and/or when the loop pump has (probably unrealistically) high power.

No regression test results or documentation changes.
