### PR TITLE
Design day CSV export code

### DIFF
--- a/src/CNRECS.DEF
+++ b/src/CNRECS.DEF
@@ -790,7 +790,7 @@ RECORD WDHR "wfdata sub" *SUBSTRUCT	// hourly data substructure for WFDATA
 	*prefix wd_
     *declare "void wd_Init( int options=0);"
     *declare "WDHR& Copy( const WDHR& wd, int options=0);"
-    *declare "void wd_WriteCSV( int jDayST, int iHr) const;"
+    *declare "void wd_WriteCSV( const char* dateStr, const WDHR& wdx, int iHr) const;"
 	*declare "RC wd_WfReader( BOO nextHour, WFILE* pWF);"
 	*declare "void wd_Adjust( int iHrST);"
 	*declare "void wd_SetSolarValues( int jDayST, int iHrST);"

--- a/src/cgwthr.cpp
+++ b/src/cgwthr.cpp
@@ -438,7 +438,16 @@ RC TOPRAT::tp_WthrFillDsDay(
 				{	// DESCOND design day: overwrite/adjust weather file values with generated
 					int iDC = tp_coolDsCond[tp_dsDayI - 1];
 					const DESCOND& DC = DcR[iDC];
+#undef WRITECSVDESDAY	// define to enable CSV export of some design day data
+						//   model development / experimental aid re e.g. comparison
+						//   of ASHRAE clear sky to weather file solar  7/2024
+#if defined( _DEBUG) && defined( WRITECSVDESDAY)
+					WDHR wdx = wd;	// copy of weather file data
+#endif
 					wd.wd_FillFromDESCOND(DC, iH);
+#if defined( _DEBUG) && defined( WRITECSVDESDAY)
+					wd.wd_WriteCSV(dateStr.CStr(), wdx, iH);
+#endif
 				}
 			}
 		}

--- a/src/wfpak.cpp
+++ b/src/wfpak.cpp
@@ -387,7 +387,8 @@ RC WDHR::wd_Unpack(		// single-hour unpack
 //--------------------------------------------------------------------------
 #if defined( _DEBUG)
 void WDHR::wd_WriteCSV(			// data writer for ad-hoc exports
-	int jDayST,
+	const char* dateStr,
+	const WDHR& wdx,			// alternative hourly data
 	int iH) const
 {
 	static FILE* pF = NULL;		// file
@@ -395,12 +396,17 @@ void WDHR::wd_WriteCSV(			// data writer for ad-hoc exports
 	{
 		const char* fName = "wdhr.csv";
 		pF = fopen(fName, "wt");
-		if (pF)
-			fprintf(pF, "doy,hr,tdb,dni,dhi,ghi\n");
+	
 	}
 	if (pF)
-		fprintf(pF, "%d,%d,%0.1f,%0.1f,%0.1f,%0.1f\n",
-			jDayST, iH, wd_db, wd_DNI, wd_DHI, wd_glrad);
+	{
+		if (iH == 0)
+			fprintf(pF, "%s\nhr,wf tdb,wf dni,wf dhi,wf ghi,dc tdb,dc dni,dc dhi,dc ghi\n", dateStr);
+		fprintf(pF, "%d,%0.1f,%0.1f,%0.1f,%0.1f,%0.1f,%0.1f,%0.1f,%0.1f\n",
+			iH,
+			wdx.wd_db, wdx.wd_DNI, wdx.wd_DHI, wdx.wd_glrad,
+			wd_db, wd_DNI, wd_DHI, wd_glrad);
+	}
 
 }		// WDHR::wd_WriteCSV
 #endif


### PR DESCRIPTION
## Description

Adds conditional code that writes a CSV file containing design-day data.  This is for model development and comparison.

It is useful to keep this code for possible future use.  Deemed unnecessarily cumbersome to maintain a branch to retain a few lines of code, so they are being added to main as inactive conditional code.

No documentation changes.  No regression test impacts.
