### PR TITLE
32 bit TI (eliminate 32767 record limit)

### DIFF
--- a/src/CNDTYPES.DEF
+++ b/src/CNDTYPES.DEF
@@ -67,11 +67,11 @@ UCH      --		"unsigned char"
 SI       --		"int16_t"			
 USI      --		"uint16_t"
 BOO      --     "int16_t"		// unambiguous 16-bit Boolean
-TI       --		"SI"				// (rat) table index (subscript); 0 means unset.
 
 // INT and variants: always 32 bits
 INT      --   "int32_t"
 UINT     --   "uint32_t"
+TI       --   "int32_t"			// (rat) table index (subscript); 0 means unset.
 
 // LI and variants: same size as pointer (4 on 32 bit / 8 on 64 bit)
 #if CSE_ARCH == 64

--- a/src/ancrec.cpp
+++ b/src/ancrec.cpp
@@ -853,7 +853,9 @@ void FC basAnc::regis()				// "register" anchor for nextAnc() iteration.  Constr
 	ancN = an;							// set index in anchor
 }		// basAnc::regis
 //---------------------------------------------------------------------------------------------------------------------------
-void basAnc::desRecs( SI _mn, SI _n)
+void basAnc::desRecs(		// delete records
+	TI _mn /*=0*/,  // 1st record to delete
+	TI _n /*=TI_MAX*/)	// last record to delete
 {
 	//if (mn <= n)					// if any records allocated: protection for ptr vf call if nec??
 	if (ptr())						// if record memory is allocated
@@ -918,10 +920,10 @@ RC FC basAnc::reAl( TI _n, int erOp/*=ABT*/)		// allocate space for n (0=default
 		return RCBAD;	// check anchor
 #endif
 	if (_n < 1)
-		_n = 1 + 1024/eSz;			// if # records not specified, use 1k's worth plus 1
+		_n = max( 5, 1024/eSz);		// if # records not specified, use 1k's worth (at least 5)
 	TI _nAl = _n+1;					// space [0] not used (all 0's for grounding) --> max subscr+1 is n+1
 	size_t sz = _nAl * eSz;			// size that must be allocated
-	desRecs(_nAl, 32767); 			// insurance: destroy any excess existing records if making block smaller
+	desRecs(_nAl); 					// insurance: destroy any excess existing records if making block smaller
 	record* ptrWas = ptr();			// NULL if this is initial allocation
 	RC rc = dmral( pptr(), sz, erOp|DMZERO);	// (re)alloc memory, zero new space, dmpak.cpp
 	if (rc)								// if failed
@@ -982,8 +984,12 @@ RC basAnc::add(		// construct record i (0 = next). Allocs if nec.
 	if ( i >= nAl  					// if (more) record spaces must be allocated (nAl is +1; i,n are not)
 	 ||  !ptr() )   				// insurance
 	{
-		UINT sz = (UINT)nAl*eSz + 1024;			// new size in bytes to add 1 + 1K's worth of record spaces (nAl is +1)
-		TI _n = max( (USI)(sz/eSz), (USI)i);	// add 1 + 1K's worth of spaces, or to req'd rec # if more.
+#if 1	// add bigger chunks for big records, 9-3-2024
+		TI _n = max(i, nAl + max(5, 1024/eSz));	// new count: add 5 or 1K's worth (at least callers req'd rec #)
+#else
+0		UINT sz = (UINT)nAl*eSz + 1024;	// new size in bytes to add 1 + 1K's worth of record spaces (nAl is +1)
+0		TI _n = max( sz/eSz, UINT( i));	// add 1 + 1K's worth of spaces, or to req'd rec # if more.
+#endif
 		if (reAl(_n, erOp))
 			return RCBAD; 		// (re)alloc rec spaces 1.._n, init nAl, ptr(), space[0], etc. above.
 	}

--- a/src/ancrec.h
+++ b/src/ancrec.h
@@ -27,6 +27,8 @@ typedef basAnc* BP;	// basAnc pointer -- formerly used to localize NEARness
  			   skip these bytes in bitwise memset/memcpy operations.
  			   Far forced 2-94 with compile option so same in 16/32 and in large/huge (srfd.cpp is huge) */
 
+inline constexpr TI TI_MAX = INT_MAX;	// maximum number of records in rat
+
 /*---- Field (member) Status Byte Bits --------------------------------------
 
    These are in  unsigned char sstat[]  array generated at end of each record
@@ -125,7 +127,7 @@ class basAnc    	// base class for record anchors: basAnc<recordName>
 protected:
     virtual void conRec( TI i, SI noZ=0) = 0;			// execute constructor for record i
     virtual void desRec( TI i) = 0;				// .. destructor
-    void desRecs( TI mn=0, TI n=32767); 			// destroy all or range of records (as b4 freeing block)
+    void desRecs( TI mn=0, TI n=TI_MAX); 		// destroy all or range of records (as b4 freeing block)
 };				// class basAnc
 
 // for ARRAY field, the following are used in each element's status byte
@@ -373,7 +375,7 @@ template <class T>  class anc : public basAnc
 
 
  protected:
-    void desRecs( TI mn=0, TI n=32767); 			// ~ all records or range (as b4 freeing block)
+    // void desRecs( TI mn=0, TI n=32767); 			// ~ all records or range (as b4 freeing block)
     virtual void desRec( TI i)
 	{	if (p[i].r_status)
 			p[i].T::~T();	// destroy record if constructed
@@ -457,13 +459,15 @@ x    n = nAl = 0;				// say no records in use, none allocated: insurance
     }
 }		// anc<T>::~anc
 //-------------------------------------------------------------------------------------------------------------------------
-template <class T> void anc<T>::desRecs( SI _mn, SI _n)
+#if 0
+template <class T> void anc<T>::desRecs( TI _mn, TI _n)
 // ?? why isn't basAnc::desRecs sufficient, 5-31-92?
 {
     if (ptr()) 						// if record memory is allocated
        for (TI i = max(mn,_mn);  i <= min(n,_n);  i++) 	// loop allocated record spaces in range given by caller
           desRec(i);					// conditionally destroy record in space with record-deriv d'tor ~T.
 }			// anc<T>::desRecs
+#endif
 //-------------------------------------------------------------------------------------------------
 template <class T> int anc<T>::GetCount(
 	int options) const	// passed to T.IsCountable

--- a/src/ancrec.h
+++ b/src/ancrec.h
@@ -375,7 +375,6 @@ template <class T>  class anc : public basAnc
 
 
  protected:
-    // void desRecs( TI mn=0, TI n=32767); 			// ~ all records or range (as b4 freeing block)
     virtual void desRec( TI i)
 	{	if (p[i].r_status)
 			p[i].T::~T();	// destroy record if constructed
@@ -459,16 +458,6 @@ x    n = nAl = 0;				// say no records in use, none allocated: insurance
     }
 }		// anc<T>::~anc
 //-------------------------------------------------------------------------------------------------------------------------
-#if 0
-template <class T> void anc<T>::desRecs( TI _mn, TI _n)
-// ?? why isn't basAnc::desRecs sufficient, 5-31-92?
-{
-    if (ptr()) 						// if record memory is allocated
-       for (TI i = max(mn,_mn);  i <= min(n,_n);  i++) 	// loop allocated record spaces in range given by caller
-          desRec(i);					// conditionally destroy record in space with record-deriv d'tor ~T.
-}			// anc<T>::desRecs
-#endif
-//-------------------------------------------------------------------------------------------------
 template <class T> int anc<T>::GetCount(
 	int options) const	// passed to T.IsCountable
 {

--- a/src/cncp.cpp
+++ b/src/cncp.cpp
@@ -475,7 +475,7 @@ BOO COOLPLANT::nxChStg( CHILLER *&ch, int _stgi /*=-1*/ )  	// first/next chille
 	}
 
 // access stage's chiller info
-	TI* stg = (SI *)((char *)cpStage1 + _stgi * sizeof(cpStage1));	// assumes stage arrays same and in order.
+	TI* stg = (TI *)((char *)cpStage1 + _stgi * sizeof(cpStage1));	// assumes stage arrays same and in order.
 
 // access next chiller of stage.  Code similar to AH::nxTsCzn, HEATPLANT::nxBlrStg
 	TI* chs;							// temp for ptr into stg[]

--- a/src/cncult4.cpp
+++ b/src/cncult4.cpp
@@ -326,7 +326,7 @@ RC topCol( int isExport)
 		rp->wid += colp->colGap + colp->colWid;
 
 		// add this column to end of column list for its report
-		SI* pNxColi;
+		TI* pNxColi;
 		for (pNxColi = &rp->coli;  *pNxColi;  pNxColi = &colB->p[*pNxColi].nxColi )	// find end of list so far
 			;
 		*pNxColi = colp->ss;			// set rp->coli (1st column) or prev column->nxColi

--- a/src/cnhp.cpp
+++ b/src/cnhp.cpp
@@ -420,7 +420,7 @@ BOO HEATPLANT::nxBlrStg( BOILER *&blr, SI _stgi /*=-1*/ )  	// first/next boiler
 	}
 
 // access stage's boiler info
-	TI* stg = (SI *)((char *)hpStage1 + _stgi * sizeof(hpStage1));	// assumes stage arrays same and in order.
+	TI* stg = (TI *)((char *)hpStage1 + _stgi * sizeof(hpStage1));	// assumes stage arrays same and in order.
 
 // access next boiler of stage.  Code similar to AH::nxTsCzn.
 	TI* blrs;							// temp for ptr into stg[]

--- a/src/cul.cpp
+++ b/src/cul.cpp
@@ -2425,7 +2425,8 @@ LOCAL RC FC datPt()		// point to DAT and KDAT data storage per xSp->c, e, fs0
 		case TYIREF:
 		case TYREF:
 			dtMustBe = DTTI;
-			break;  		// sz = 2 preset
+			sz = sizeof(TI);
+			break;
 		case TYDOY:
 			dtMustBe = DTDOY;
 			break;


### PR DESCRIPTION
## Description

Change TI from 16 bit (int16_t) to 32 bit (int32_t).  This allows CSE to have more than 32767 records in a given RAT.

No results changes.  No documentation changes.

Note: modified code does not detect / handle other memory limits.  See issue 502.


