### PR TITLE
Improve unit-handling in HPWHsim

### DIFF
--- a/src/dhwcalc.cpp
+++ b/src/dhwcalc.cpp
@@ -4262,7 +4262,7 @@ int DHWHEATER::wh_IsScalable() const		// can heating capacity be set
 	if (wh_IsHPWHModel())
 	{
 		ret = wh_HPWH.hw_pHPWH
-				? wh_HPWH.hw_pHPWH->isHPWHScalable()
+				? wh_HPWH.hw_pHPWH->isScalable()
 				: -1;
 	}
 	// else
@@ -4676,7 +4676,7 @@ RC DHWHEATER::wh_HPWHInit()		// initialize HPWH model
 
 	if (!rc && IsSet(DHWHEATER_HEATINGCAP))
 	{	// check whether heating capacity can be adjusted
-		if (!wh_HPWH.hw_pHPWH->isHPWHScalable() || !wh_HPWH.hw_HasCompressor())
+		if (!wh_HPWH.hw_pHPWH->isScalable() || !wh_HPWH.hw_HasCompressor())
 		{	if (wh_heatSrc == C_WHHEATSRCCH_ASHPX)
 				rc |= oer("whHeatingCap is not allowed when whASHPType=%s",
 					getChoiTx(DHWHEATER_ASHPTY, 1));

--- a/src/dhwcalc.cpp
+++ b/src/dhwcalc.cpp
@@ -3330,8 +3330,8 @@ RC HPWHLINK::hw_SetHeatingCap(			// set heating capacity
 		//   (handles e.g. possible low-temp lockout)
 		hw_pHPWH->setResistanceCapacity(heatingCap, 0, HPWH::UNITS_BTUperHr);
 	} catch (...) {
-		// unexpected HPWH error (inconsistent HPWH::isHPWHScalable() logic?)
-		//   isHPWHScalable() checked in wh_HPWHInit()
+		// unexpected HPWH error (inconsistent HPWH::isScalable() logic?)
+		//   isScalable() checked in wh_HPWHInit()
 		rc = hw_pOwner->oer(
 			"Program error (HPWHLINK::hw_SetHeatingCap): HPWH error");
 	}


### PR DESCRIPTION
-Significant overhaul of unit-handling in HPWHsim. Physical quantities are transmitted to/from HPWHsim as objects with a units property. A parameter such as temperature can be specified directly in a function call to HPWHsim using the form {20., Units::C}. A returned quantity is converted to a double of appropriate dimensions using a form such as hw_pHPWH->getTankHeatContent()(Units::kWh).

-Several cse regression tests failed as a result of slight differences in physical constants.