### PR TITLE
Bug fix: DWHR accounting correction to fix DHW energy balance warnings

### DIFF
--- a/src/CNRECS.DEF
+++ b/src/CNRECS.DEF
@@ -4867,9 +4867,9 @@ RECORD DHWHEATREC "DHWHeatRec" *RAT	// input / runtime drain water heat recovery
 							//    _HORIZ or _VERT: effectiveness adjusted per CASE regressions
 							//          depending on flows and temps, same model for both
 							//    _SETEF: wr_effRated used w/o modification (testing aid)
-  *i SI_GEZ wr_nFXDrain		// number of fixtures (of type wr_whEndUse) draining
+  *i SI_GEZ wr_nFXDrain		// number of fixtures (of type wr_hwEndUse) draining
 							//    via this DHWHEATREC
-  *i SI_GEZ wr_nFXCold		// number of fixtures (of type wr_whEndUse) draining
+  *i SI_GEZ wr_nFXCold		// number of fixtures (of type wr_hwEndUse) draining
 							//    via this DHWHEATREC with cold source = this DHWHEATREC
 							//    default = wr_nFXDrain
 							//    if < wr_nFXDrain, remainder have cold source = mains

--- a/src/dhwcalc.cpp
+++ b/src/dhwcalc.cpp
@@ -3705,7 +3705,10 @@ RC HPWHLINK::hw_DoSubhrTick(		// calcs for 1 tick
 		//   on mixing ratio from prior step (set below)
 		//   CHDHW (space heating) draws are not mixed
 		double scaleX = scaleWH * hw_fMixUse;
-		tk.wtk_qDWHR *= hw_fMixUse;
+		tk.wtk_qDWHR *= hw_fMixUse;	// apply mixing ratio to qDWHR to *approximately* account for reduced flow.
+									// "Really" should change DWHR outlet temp also, but that would require
+									//    interleaving DWHR / DHWHEATER tick-level calcs.
+									//  Approximation is OK given overall model accuracy.
 		drawUse = tk.wtk_whUse * scaleX;
 		drawLoss = tk.wtk_qLossNoRL * scaleX / (waterRhoCp * max(1., tMix - tMains));
 		tk.wtk_volIn += (drawUse + drawLoss) / scaleWH;		// note +=

--- a/src/dhwcalc.cpp
+++ b/src/dhwcalc.cpp
@@ -1816,6 +1816,19 @@ RC DHWSYS::ws_DoHourDWHR()		// current hour DHWHEATREC modeling (all DHWHEATRECs
 	// hour average adjusted inlet and hot water temps
 	float tInletX = ws_tInlet + ws_qDWHRWH / (waterRhoCp * ws_whUse.total);
 
+	int nTk = Top.tp_NHrTicks();
+	float tUseSum = 0.f;
+	float useSum = 0.f;
+	for (int iTk = 0; iTk < nTk; iTk++)
+	{
+		DHWTICK& tk = ws_ticks[iTk];		// DHWSYS tick info
+		tUseSum += tk.wtk_tInletX * tk.wtk_whUse;
+		useSum += tk.wtk_whUse;
+	}
+	float tInletX2 = tUseSum / max(useSum, 0.01f);
+	if (abs(tInletX-tInletX2) > .001f)
+		printf("\nDHWSYS '%s': tInletX mismatch", Name());
+
 	// hour energy balance
 	float qXNoHR = ws_whUseNoHR * waterRhoCp * (ws_tUse - ws_tInlet);
 	float qX =     ws_whUse.total * waterRhoCp * (ws_tUse - tInletX);
@@ -3692,6 +3705,7 @@ RC HPWHLINK::hw_DoSubhrTick(		// calcs for 1 tick
 		//   on mixing ratio from prior step (set below)
 		//   CHDHW (space heating) draws are not mixed
 		double scaleX = scaleWH * hw_fMixUse;
+		tk.wtk_qDWHR *= hw_fMixUse;
 		drawUse = tk.wtk_whUse * scaleX;
 		drawLoss = tk.wtk_qLossNoRL * scaleX / (waterRhoCp * max(1., tMix - tMains));
 		tk.wtk_volIn += (drawUse + drawLoss) / scaleWH;		// note +=


### PR DESCRIPTION
## Description

DHW energy balance warnings have been seen in CZ16 compliance runs using HPWH.  Isolated the cause to be DWHR (which is typically used only in CZ16).

Fix: Apply mixdown factor (hw_fMixUse) to DWHR recovered energy (qDWHR).  Motivation: qDWHR is derived assuming full draw flow volume.  However, when the mixdown factor is invoked to maintain tUse, the draw is reduced.  Thus, qDWHR should be reduced by the same factor.

Note that "really", the reduced draw would change (increase) the heat exchanger outlet temperature, so qDWHR would be reduced by less than hw_fMixUse.  Currently the heat recovery calculation is done before mixdown is known.  Further, heat recovery is calculated for all ticks in an hour, rather than tick-by-tick.  Substantial code reorganization would be required to capture the mixdown effect within the heat recovery calculation.  Applying the mixdown factor after the fact is close enough.

This change alters qDWHR only, which is an output value that participates in the energy balance but does not impact primary energy results.  Thus no compliance impact.

No regression results changes.

No documentation changes.

