### PR TITLE
First 10 airnet converge failures treated as warnings

### DIFF
--- a/src/cgcomp.cpp
+++ b/src/cgcomp.cpp
@@ -2585,7 +2585,7 @@ RC AIRNET_SOLVER::an_Calc(			// airnet flow balance
 	}
 
 	if (!bConverge)
-		err(WRN, "%s: AirNet convergence failure", Top.When(C_IVLCH_S));
+		warn("%s: AirNet convergence failure", Top.When(C_IVLCH_S));
 
 	// change tiny pressures to 0
 	//   prevents trouble when doubles assigned to floats

--- a/src/cgcomp.cpp
+++ b/src/cgcomp.cpp
@@ -2315,7 +2315,7 @@ struct AIRNET_SOLVER
 {
 	AIRNET_SOLVER( AIRNET* pParent)
 		: an_pParent( pParent), an_nz( 0), an_jac(), an_V1(), an_V2(), an_mdotAbs(nullptr),
-		  an_didLast(nullptr), an_unreasonablePressureCount( 0)
+		  an_didLast(nullptr), an_convergeFailCount( 0)
 	{ }
 	~AIRNET_SOLVER()
 	{
@@ -2338,8 +2338,7 @@ struct AIRNET_SOLVER
 
 	double* an_mdotAbs;		// total abs flow by zone (nz)
 	int* an_didLast;	    // re relax scheme (see code) (nz)
-	int an_unreasonablePressureCount;	// count of unreasonable zone pressure results
-										//   see an_Checkresults
+	int an_convergeFailCount;	// count of an_Calc() convergence failure
 
 
 };		// struct AIRNET_SOLVER
@@ -2403,7 +2402,7 @@ RC AIRNET_SOLVER::an_Calc(			// airnet flow balance
 	//   dflt=.0001
 #endif
 
-	RC rc = RCBAD;
+	RC rc = RCOK;
 	an_pParent->an_resultsClear[iV] = 0;	// set flag for an_ClearResults()
 
 	an_nz = ZrB.GetCount();
@@ -2435,8 +2434,11 @@ RC AIRNET_SOLVER::an_Calc(			// airnet flow balance
 	int zi;
 	int zi0 = ZrB.GetSS0();		// zone subscript offset (re 0-based arrays used here)
 	bool bConverge = false;		// set true when converged
+
+	// iterate to find mass balance for all zones
+	//   iteration limit changed 20->30 to fix occaisional large-project convergence fail 4-29-2025
 	int iter;
-	for (iter = 0; iter < 20; iter++)
+	for (iter = 0; iter < 30; iter++)
 	{
 		an_jac.setZero();
 		rV->setZero();
@@ -2585,7 +2587,11 @@ RC AIRNET_SOLVER::an_Calc(			// airnet flow balance
 	}
 
 	if (!bConverge)
+	{	
 		warn("%s: AirNet convergence failure", Top.When(C_IVLCH_S));
+		if (++an_convergeFailCount > 10)
+			rc = err(WRN, "Too many AirNet convergence failures, terminating.");
+	}
 
 	// change tiny pressures to 0
 	//   prevents trouble when doubles assigned to floats
@@ -2595,8 +2601,6 @@ RC AIRNET_SOLVER::an_Calc(			// airnet flow balance
 		if (fabs(zp->zn_pz0W[iV]) < 1.e-20)
 			zp->zn_pz0W[iV] = 0.;
 	}
-
-	rc = RCOK;
 
 	TMRSTOP(TMR_AIRNET);
 	return rc;

--- a/src/dhwcalc.cpp
+++ b/src/dhwcalc.cpp
@@ -2537,6 +2537,10 @@ float DHWSYSRES_IVL::wsr_EnergyBalance()	// calculate energy balance
 {
 	float otherSum = VSum(&qLossMisc, wsr_NFLOAT - 3);
 	qBal = qOutDHW + qOutHtg - otherSum;
+#if defined( _DEBUG)
+	if (fabs(qBal) > 5000.f)
+		printf("\nUnbal");
+#endif
 	return qBal;
 }		// DHWSYSRES_IVL::wsr
 //-----------------------------------------------------------------------------
@@ -3253,9 +3257,9 @@ RC HPWHLINK::hw_InitFinalize(		// final initialization actions
 
 	// tank inlet placement
     if (inHtSupply >= 0.f)
-    hw_pHPWH->setInletByFraction(inHtSupply);
+		hw_pHPWH->setInletByFraction(inHtSupply);
     if (inHtLoopRet >= 0.f)
-    hw_pHPWH->setInlet2ByFraction(inHtLoopRet);
+		hw_pHPWH->setInlet2ByFraction(inHtLoopRet);
 
     // make map of heat sources = idxs for hw_HPWHUse[]
     // WHY: HPWH model frequently uses 3 heat sources in
@@ -3662,12 +3666,16 @@ RC HPWHLINK::hw_DoSubhrTick(		// calcs for 1 tick
 {
 	RC rc = RCOK;
 
-#if 0 && defined( _DEBUG)
-	if (Top.tp_date.month == 7
-		&& Top.tp_date.mday == 27
-		&& Top.iHr == 10
+#if 1 && defined( _DEBUG)
+	if (Top.tp_date.month == 1
+		&& Top.tp_date.mday == 11
+		&& Top.iHr == 3
 		&& Top.iSubhr == 3)
-		hw_pHPWH->setVerbosity(HPWH::VRB_emetic);
+	{	printf("\nHit %.0f", tk.wtk_startMin);
+		hw_bWriteCSV = 1;
+	}
+	else
+		hw_bWriteCSV = 0;
 #endif
 
 	// draw components for tick


### PR DESCRIPTION
## Description

Change handling of airnet convergence failures to tolerate a few convergence failures.  Convergence failures have been seen occasionally in models with a large number of zones (e.g. multifamily cases with e.g. 80 zones).

Was: Max 20 iterations, 1st failure = error (run terminated)

Now: Max 30 iterations, 10 failures treated as warnings (run continues).  11th failure is error.

No results changes (except for runs that formerly did not complete)

No documentation changes.