### PR TITLE
Update Windows platform toolset to v143

### DIFF
--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -16,7 +16,7 @@ endif ()
 
 if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
     if (${COMPILER_ID} STREQUAL "msvc")
-        set(configure_command ${configure_command} -T v142,version=14.29.16.11 -A ${TARGET_VS_ARCHITECTURE} -DCMAKE_SYSTEM_VERSION=10.0.20348.0)
+        set(configure_command ${configure_command} -T v143 -A ${TARGET_VS_ARCHITECTURE} -DCMAKE_SYSTEM_VERSION=10.0.20348.0)
     elseif(${COMPILER_ID} STREQUAL "clang")
         set(configure_command ${configure_command} -T ClangCL -A ${TARGET_VS_ARCHITECTURE})
     endif ()

--- a/test/ref-win32-msvc/PERFMAP3.REP
+++ b/test/ref-win32-msvc/PERFMAP3.REP
@@ -581,7 +581,7 @@ RSYS hours for Thu 15-Jan
 
 ! Log for Run 001:
 
-! CSE 0.923.0+vchp-fanpower.148a22e8.1.dirty for Win32 console
+! CSE 0.925.0+update-platform-toolset.2aeb7f4a.49 for Win32 console
 
 
 
@@ -1589,7 +1589,7 @@ RSYS hours for Thu 15-Jan
 
 ! Log for Run 002:
 
-! CSE 0.923.0+vchp-fanpower.148a22e8.1.dirty for Win32 console
+! CSE 0.925.0+update-platform-toolset.2aeb7f4a.49 for Win32 console
 
 
 
@@ -1605,11 +1605,11 @@ Input for Run 002:
 Error Messages for Run 002:
 
 ---------------
-PERFMAP3.CSE(110): Info: RSYS 'Sys1': 
-    'rsFanPwrH' is ignored when rsType=ACPM (heating not available)
----------------
 PERFMAP3.CSE(110): Info: 
   RSYS 'Sys1': 'rsCapH' is ignored when rsType=ACPM (heating not available)
+---------------
+PERFMAP3.CSE(110): Info: RSYS 'Sys1': 
+    'rsFanPwrH' is ignored when rsType=ACPM (heating not available)
 ---------------
 PERFMAP3.CSE(110): Info: 
   RSYS 'Sys1': 'rsAFUE' is ignored when rsType=ACPM (heating not available)
@@ -2201,7 +2201,7 @@ RSYS hours for Thu 15-Jan
 
 ! Log for Run 003:
 
-! CSE 0.923.0+vchp-fanpower.148a22e8.1.dirty for Win32 console
+! CSE 0.925.0+update-platform-toolset.2aeb7f4a.49 for Win32 console
 
 
 
@@ -2215,11 +2215,11 @@ Input for Run 003:
         
         RUN
 -----------------------
-???     PERFMAP3.CSE(110): Info: RSYS 'Sys1': 
-???         'rsFanPwrH' is ignored when rsType=ACPM (heating not available)
------------------------
 ???     PERFMAP3.CSE(110): Info: 
 ???       RSYS 'Sys1': 'rsCapH' is ignored when rsType=ACPM (heating not available)
+-----------------------
+???     PERFMAP3.CSE(110): Info: RSYS 'Sys1': 
+???         'rsFanPwrH' is ignored when rsType=ACPM (heating not available)
 -----------------------
 ???     PERFMAP3.CSE(110): Info: 
 ???       RSYS 'Sys1': 'rsAFUE' is ignored when rsType=ACPM (heating not available)
@@ -2234,18 +2234,18 @@ Input for Run 003:
 
 
 
-! CSE 0.923.0+vchp-fanpower.148a22e8.1.dirty for Win32 console run(s) done: Fri 10-Jan-25   3:1 pm
+! CSE 0.925.0+update-platform-toolset.2aeb7f4a.49 for Win32 console run(s) done: Tue 03-Jun-25   3:5 pm
 
-! Executable:   d:\cse\builds\cse.exe
-!               10-Jan-25   3:0 pm   (VS 14.29    2941952 bytes)  (HPWH 1.24.0)
-! Command line: -x!  -t1 perfmap3
-! Input file:   D:\cse\test\perfmap3.cse
-! Report file:  D:\CSE\TEST\PERFMAP3.REP
+! Executable:   d:\a\cse\cse\build\cse.exe
+!               03-Jun-25   3:5 pm   (VS 14.43    3482112 bytes)  (HPWH 1.25.0+HEAD.cc0bb806.445)
+! Command line: -x!  -b -t1 perfmap3
+! Input file:   D:\a\cse\cse\test\perfmap3.cse
+! Report file:  D:\A\CSE\CSE\TEST\PERFMAP3.REP
 
 ! Timing info --
 
-!                Input:  Time = 0.14     Calls = 3         T/C = 0.0457
+!                Input:  Time = 0.18     Calls = 3         T/C = 0.0617
 !           AutoSizing:  Time = 0.00     Calls = 0         T/C = 0.0000
-!           Simulation:  Time = 1.18     Calls = 3         T/C = 0.3943
-!              Reports:  Time = 0.01     Calls = 3         T/C = 0.0017
-!                Total:  Time = 1.34     Calls = 1         T/C = 1.3370
+!           Simulation:  Time = 1.83     Calls = 3         T/C = 0.6113
+!              Reports:  Time = 0.01     Calls = 3         T/C = 0.0020
+!                Total:  Time = 2.02     Calls = 1         T/C = 2.0250


### PR DESCRIPTION
Changed the Windows platform toolset specified in `configure.cmake` from "Visual Studio 2019 (v142)" to "Visual Studio 2022 (v143)". I have not identified a specific version (toolset, compiler?), as was listed previously. The output of perfmap3.cse on Win32 changed slightly (an extra "Info" message is displayed.) This version passes the CI, but now  my local Mac gives several 0/-0 diffs in perfmap.cse, compared to the CI (due to AppleClang 14 vs. 15?).
