### PR TITLE
Drop support for '/' command line switches

### DIFF
--- a/doc/src/input-structure.md
+++ b/doc/src/input-structure.md
@@ -921,9 +921,8 @@ For *floats* and *ints*, the CSE input language recognizes a set of operators ba
 
 *Dates* are stored as *ints* (the value being the Julian day of the year), so all numeric operators could be used. The month abbreviations are implemented as operators that add the first day of the month to the following *int* value; CSE does not disallow their use in other numeric contexts.
 
-For *strings*, *object names*, and *choices*, the CSE input language currently has no operators except the ?: conditional operator. A concatenation operator is being considered. Note, though, that the choose, choose1, select, and hourval functions described below work with strings, object names, and choice values as well as numbers.
+For *strings*, *object names*, and *choices*, the CSE input language currently has no operators except the ?: conditional operator and the concat() function. Note, though, that the choose, choose1, select, and hourval functions described below work with strings, object names, and choice values as well as numbers.
 
-<!-- TODO: A string concatenation operator would be very helpful!  2010-07 -->
 ### System Variables
 
 *System Variables* are built-in operands with useful values. To avoid confusion with other words, they begin with a \$. Descriptions of the CSE system variables follow. Capitalization shown need not be matched. Most system variables change during a simulation run, resulting in the *variations* shown; they cannot be used where the context will not accept variation at least this fast. (The [Input Data Section](#input-data) gives the *variability*, or maximum acceptable variation, for each object member.)
@@ -947,10 +946,10 @@ For *strings*, *object names*, and *choices*, the CSE input language currently h
                    **Variation**: subhourly.
 
   \$dayOfWeek      Day of week, 1 - 7; 1 corresponds to Sunday, 2 to
-                   Monday, etc. **Variation:** daily.
+                   Monday, etc. Note that \$dayOfWeek is 4 (Wed) during autosizing. **Variation:** daily.
 
   \$DOWH           Day of week 1-7 except 8 on every observed holiday.
-                   **Variation**: daily.
+                   Note that \$DOWH is 4 (Wed) during autosizing **Variation**: daily.
 
   \$isHoliday      1 on days that a holiday is observed (regardless of the
                    true date of the holiday); 0 on other days.

--- a/src/cse.cpp
+++ b/src/cse.cpp
@@ -534,7 +534,7 @@ LOCAL int cse1( int argc, const char* argv[])
 			if (IsBlank( a))
 				continue;		// ignore blank or NULL (unexpected) arguments
 			argvx[argcx++] = a;			// use this arg in this run
-			if (*a != '-'  &&  *a != '/')		// if it was not a flag (not - nor / first), assume it is an input filename
+			if (!IsCmdLineSwitch( *a))		// if it was not a switch (not '-' first), assume it is an input filename
 			{
 				BOO moreFilesFollow = FALSE;
 				for (int argcj = argci;  argcj < argc; )	// scan remaining args to see if more filenames follow
@@ -542,8 +542,8 @@ LOCAL int cse1( int argc, const char* argv[])
 					const char* b = argv[argcj++];		// get one additional arg pointer
 					if (IsBlank( b))
 						continue;			// ignore blank or NULL (unexpected) arguments
-					if (*b != '-'  &&  *b != '/')	// if not a flag
-						moreFilesFollow++;			// assume it is a file name
+					if (!IsCmdLineSwitch( *b))	// if not a switch
+						moreFilesFollow++;		// assume it is a file name
 				}
 				if (moreFilesFollow) 	// if additional file args follow
 					break;				// terminate arg list for run with file name
@@ -741,12 +741,12 @@ LOCAL int cse3( int argc, const char* argv[])
 	{
 		char c0;
 		const char* arg = argv[i];
-		RC trc;
-		if (ppClargIf( arg, &trc) )	// test if a preprocessor cmd line arg such as a define or include path.
+		RC trc = RCOK;
+		if (ppClargIf( arg, trc) )	// test if a preprocessor cmd line arg such as a define or include path.
        								// If so, do it, set trc, return true.  pp.cpp.
        								// uses -d, -D, -i, -I as of 2-95
 			rc |= trc;			// merge cmd line arg error codes
-		else if ((c0 = *arg) != 0  &&  strchr("-/", *arg))	// test for switch
+		else if ((c0 = *arg) != 0 && IsCmdLineSwitch( *arg))	// test for switch
 		{
 			// warning for switch after file name, cuz confusing: apply to preceding file only if last file 2-95. Use switch anyway.
 			if (InputFileName)

--- a/src/cse.h
+++ b/src/cse.h
@@ -42,6 +42,8 @@ extern int TestOptions;				// test option bits, set via -t command line argument
   #endif
 #endif
 
+
+
 // re sending DLL screen msgs to calling EXE
 // defined but not used per LOGCALLBACK
 void LogMsgViaCallBack( const char* msg, int level=0);

--- a/src/pp.h
+++ b/src/pp.h
@@ -11,10 +11,11 @@ extern int VrInp;	// 0 or virtual report handle (vrpak.cpp) for open INPut listi
 
 /*--------------- FUNCTIONS called outside of pp.cpp files --------------*/
 
-// pp.cpp: command line interface for pp switches
-SI FC ppClargIf( const char* s, RC *prc /*,era?*/ );
+// command line interface for pp switches
+inline bool IsCmdLineSwitch( int c) { return c == '-'; }
+bool ppClargIf( const char* s, RC& rc);
 
-// pp.cpp...: re getting preprocessed text (see pp.cpp for local fcns)
+// re getting preprocessed text (see pp.cpp for local fcns)
 void FC ppClean( CLEANCASE cs);				// init/cleanup
 void ppAddPath( const char* paths);			// add path(s) to search for input/include files
 bool ppFindFile( const char *fname, char *fullPath);	// search pp paths, return full file path
@@ -26,7 +27,7 @@ RC FC ppOpen( const char* fname, char *defex);		// open file
 void FC ppClose();						// close file(s)
 USI FC ppGet( char *p, USI n);			// get preprocessed text
 
-// pp.cpp...: input listing
+// input listing
 SI   FC openInpVr();
 void FC closeInpVr();
 void FC lisFlushThruLine( int line);
@@ -34,7 +35,5 @@ void FC lisThruLine( int line);
 void FC lisMsg( char *p, int dashB4, int dashAf);
 int  FC lisFind( int fileIx, int line, const char* p, int *pPlace);
 void FC lisInsertMsg( int place, char *p, int dashB4, int dashAf);
-
-void FC dumpDefines();		// debug aid
 
 // end of pp.h


### PR DESCRIPTION
## Description

Eliminate support for '/' as prefix for command line switches due to ambiguity relative to file paths beginning with '/'.  Now the only supported form of switches is '-', e.g.

```
cse -dUX=42 myfile
``` 

Some minor cleanups also.

No results changes.

Documentation did not mention '/' switch form.  Minor documentation edits done while searching for '/' references.
