### PR TITLE
Update Windows SDK version to 10.0.26100.0

### DIFF
--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -16,6 +16,10 @@ endif ()
 
 if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
     if (${COMPILER_ID} STREQUAL "msvc")
+        # Explicitly set versions to guarantee computational stability
+        #    toolset version (-T, version)
+        #    SDK version (CMAKE_SYSTEM_VERSION)
+        #        Supported list of SDK versions: https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/
         set(configure_command ${configure_command} -T v142,version=14.29.16.11 -A ${TARGET_VS_ARCHITECTURE} -DCMAKE_SYSTEM_VERSION=10.0.26100.0)
     elseif(${COMPILER_ID} STREQUAL "clang")
         set(configure_command ${configure_command} -T ClangCL -A ${TARGET_VS_ARCHITECTURE})

--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -16,7 +16,7 @@ endif ()
 
 if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
     if (${COMPILER_ID} STREQUAL "msvc")
-        set(configure_command ${configure_command} -T v142,version=14.29.16.11 -A ${TARGET_VS_ARCHITECTURE} -DCMAKE_SYSTEM_VERSION=10.0.20348.0)
+        set(configure_command ${configure_command} -T v142,version=14.29.16.11 -A ${TARGET_VS_ARCHITECTURE} -DCMAKE_SYSTEM_VERSION=10.0.26100.0)
     elseif(${COMPILER_ID} STREQUAL "clang")
         set(configure_command ${configure_command} -T ClangCL -A ${TARGET_VS_ARCHITECTURE})
     endif ()


### PR DESCRIPTION
## Description

SDK version 10.0.20348.0 has been removed as of Visual Studio 17.14.11.

Per release notes --

The following Windows SDK versions have been removed from the Visual Studio 2022 installer: 10.0.18362.0, 10.0.20348.0 and 10.0.22000.0. If your project targets any of these SDKs you may encounter a build error such as: The Windows SDK version 10.0.22000.0 was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by right-clicking the solution and selecting "Retarget solution". To resolve this, we recommend retargeting your project to 10.0.26100.0, or an earlier supported version if necessary. For a complete list of supported SDK versions please visit: https://developer.microsoft.com/windows/downloads/sdk-archive/.

This PR updates the SDK used for CSE to 10.0.26100.0 as directed.

No results changes.
