### PR TITLE
Remove upper limit on COP in performance maps.

### DIFF
--- a/doc/src/records/rsys.md
+++ b/doc/src/records/rsys.md
@@ -24,7 +24,7 @@ ACPMFURNACE, Compressor-based cooling modeled per PERFORMANCEMAP specified in rs
 ACRESISTANCE, Compressor-based cooling and electric ('strip') heating. Cooling performance based on SEER and EER.  Primary heating input energy is accumulated to end use HTG of meter rsElecMtr.
 ACPMRESISTANCE, Cooling based on PERFORMANCEMAP specified in rsPerfMapClg. Primary heating input energy is accumulated to end use HTG of meter rsElecMtr.
 ASHP,  Air-source heat pump (compressor-based heating and cooling). Primary (compressor) heating input energy is accumulated to end use HTG of meter rsElecMtr. Auxiliary and defrost heating input energy is accumulated to end use HPBU of meter rsElecMtr or meter rsFuelMtr (depending on rsTypeAuxH).
-ASHPKGROOM,  Packaged room air-source heat pump.
+ASHPPKGROOM,  Packaged room air-source heat pump.
 ASHPHYDRONIC, Air-to-water heat pump with hydronic distribution. Compressor performance is approximated using the air-to-air model with adjusted efficiencies.
 ASHPPM, Air-to-air heat pump modeled per PERFORMANCMAPs specified via rsPerfMapHtg and rsPerfMapClg.
 WSHP,  Water-to-air heat pump.

--- a/src/curvemap.cpp
+++ b/src/curvemap.cpp
@@ -470,7 +470,7 @@ RC PERFORMANCEMAP::pm_SetupBtwxt(		// input -> Btwxt conversion
 	rc |= pm_LUCheckAndMakeVector(1, pLUCap, vCapRat, LUSize);
 	PMLOOKUPDATA* pLUCOP;
 	std::vector< double> vCOP;
-	rc |= pm_LUCheckAndMakeVector(2, pLUCOP, vCOP, LUSize, 0.1, 20.);
+	rc |= pm_LUCheckAndMakeVector(2, pLUCOP, vCOP, LUSize, 0.1);
 
 	if (rc)
 		return rc;


### PR DESCRIPTION
Certain combinations of SEER2 and EER2 input into the RESNET method result in cooling COPs at low temperatures above 20. This is not unrealistic, and shouldn't produce an error.