### PR TITLE
Fix weather file path corruption

### DIFF
--- a/src/cgwthr.cpp
+++ b/src/cgwthr.cpp
@@ -60,6 +60,7 @@ void FC cgWthrClean( 		// cgwthr overall init/cleanup routine
 
 }		// cgWthrClean
 //---------------------------------------------------------------------------
+#if defined( TRAPMUNGEDWFNAME)
 bool WfCheck(const char* where)
 {
 	extern TOPRAT Topi;
@@ -80,6 +81,7 @@ bool WfCheck(const char* wfName, const char* where)
 	return bRet;
 
 }	// ::WfCheck
+#endif
 //---------------------------------------------------------------------------
 RC TOPRAT::tp_WthrBegDay()
 {

--- a/src/cgwthr.cpp
+++ b/src/cgwthr.cpp
@@ -61,6 +61,7 @@ void FC cgWthrClean( 		// cgwthr overall init/cleanup routine
 }		// cgWthrClean
 //---------------------------------------------------------------------------
 #if defined( TRAPMUNGEDWFNAME)
+// debug aid re issue #619 (delete when fix verified)
 bool WfCheck(const char* where)
 {
 	extern TOPRAT Topi;

--- a/src/cgwthr.cpp
+++ b/src/cgwthr.cpp
@@ -60,6 +60,27 @@ void FC cgWthrClean( 		// cgwthr overall init/cleanup routine
 
 }		// cgWthrClean
 //---------------------------------------------------------------------------
+bool WfCheck(const char* where)
+{
+	extern TOPRAT Topi;
+	bool bRet = true;
+	if (!Topi.tp_wfName.IsNANDLE())
+		bRet = WfCheck(Topi.tp_wfName, where);
+	return bRet;
+}	// ::WfCheck
+//--------------------------------------------------------------------------
+bool WfCheck(const char* wfName, const char* where)
+{
+	bool bRet = wfName[0] == 'C' && wfName[1] == ':';
+	if (!bRet)
+	{
+		int wflen = strlenInt(wfName);
+		warn("WFX munge '%s': '%s' len=%d", where, wfName, wflen);
+	}
+	return bRet;
+
+}	// ::WfCheck
+//---------------------------------------------------------------------------
 RC TOPRAT::tp_WthrBegDay()
 {
 	RC rc = RCOK;

--- a/src/cnglob.h
+++ b/src/cnglob.h
@@ -285,9 +285,14 @@ extern UINT doControlFP();
 #define FPCHECK ;
 #endif
 
+// debug aid: traps corrupted Topi.tp_wfName
+//  code out when fix known OK  20260508
+#undef TRAPMUNGEDWFNAME
+#if defined( TRAPMUNGEDWFNAME)
 extern bool WfCheck(const char*, const char*);
 extern bool WfCheck(const char*);
 #define WFX2( where) WfCheck( where)
+#endif
 
 // floating point compare
 const double ABOUT0 = 0.001;

--- a/src/cnglob.h
+++ b/src/cnglob.h
@@ -285,7 +285,7 @@ extern UINT doControlFP();
 #define FPCHECK ;
 #endif
 
-// debug aid: traps corrupted Topi.tp_wfName
+// debug aid: traps corrupted Topi.tp_wfName (issue #619)
 //  code out when fix known OK  20260508
 #undef TRAPMUNGEDWFNAME
 #if defined( TRAPMUNGEDWFNAME)

--- a/src/cnglob.h
+++ b/src/cnglob.h
@@ -285,6 +285,10 @@ extern UINT doControlFP();
 #define FPCHECK ;
 #endif
 
+extern bool WfCheck(const char*, const char*);
+extern bool WfCheck(const char*);
+#define WFX2( where) WfCheck( where)
+
 // floating point compare
 const double ABOUT0 = 0.001;
 template< typename T> inline int fAboutEqual(T a, T b) { return fabs(a-b) < ABOUT0; }

--- a/src/cuparse.cpp
+++ b/src/cuparse.cpp
@@ -1017,9 +1017,14 @@ RC FC exOrk(	// compile expression from current input file, return constant valu
 		// fetch from konstize's storage, condition value
 		if (gotTy == TYSTR)				// pv points to ptr to text
 		{
+#if 1
+			AsCULSTR(&v) = *(const char**)pv;	// convert to CULSTR (copies)
+			AsCULSTR(&v).IsValid();					// msg if invalid
+#else
 			CULSTR sv = *(const char**)pv;	// convert to CULSTR (copies)
 			sv.IsValid();					// msg if invalid
 			v = AsNANDAT(sv);
+#endif
 		}
 		else if (gotTy==TYSI		// SI (short int)
 		  || (gotTy==TYCH && (choiDt & DTBCHOICB) && !ISNCHOICE(*(void**)pv)))	// choice, 2-byte ch req'd, didn't get 4-byte ch

--- a/src/cuparse.cpp
+++ b/src/cuparse.cpp
@@ -1017,14 +1017,8 @@ RC FC exOrk(	// compile expression from current input file, return constant valu
 		// fetch from konstize's storage, condition value
 		if (gotTy == TYSTR)				// pv points to ptr to text
 		{
-#if 1
 			AsCULSTR(&v) = *(const char**)pv;	// convert to CULSTR (copies)
 			AsCULSTR(&v).IsValid();					// msg if invalid
-#else
-			CULSTR sv = *(const char**)pv;	// convert to CULSTR (copies)
-			sv.IsValid();					// msg if invalid
-			v = AsNANDAT(sv);
-#endif
 		}
 		else if (gotTy==TYSI		// SI (short int)
 		  || (gotTy==TYCH && (choiDt & DTBCHOICB) && !ISNCHOICE(*(void**)pv)))	// choice, 2-byte ch req'd, didn't get 4-byte ch

--- a/src/exman.cpp
+++ b/src/exman.cpp
@@ -716,8 +716,10 @@ RC exPile(		// compile an expression from current input
 			*pCS = std::move(AsCULSTR(&v));
 			// CULSTR move Release()s v, d'tor not needed
 			pCS->IsValid();		// message if malformed
+#if defined( TRAPMUNGEDWFNAME)
 			if (!WFX2(strtprintf("exPile store '%s'", AsCULSTR(&v).CStr())))
 				throw 99;
+#endif
 		}
 		else
 		{

--- a/src/exman.cpp
+++ b/src/exman.cpp
@@ -711,7 +711,14 @@ RC exPile(		// compile an expression from current input
 			// "    4-byte choice value returned by exOrk for 2-byte type".  devel aid
 		}
 		else if (gotTy == TYSTR)
-			*reinterpret_cast<CULSTR*>(pDest) = AsCULSTR(&v);
+		{
+			CULSTR* pCS = reinterpret_cast<CULSTR*>(pDest);
+			*pCS = std::move(AsCULSTR(&v));
+			// CULSTR move Release()s v, d'tor not needed
+			pCS->IsValid();		// message if malformed
+			if (!WFX2(strtprintf("exPile store '%s'", AsCULSTR(&v).CStr())))
+				throw 99;
+		}
 		else
 		{
 			*pDest = v;				// all other types return 32 bits

--- a/src/exman.cpp
+++ b/src/exman.cpp
@@ -717,6 +717,7 @@ RC exPile(		// compile an expression from current input
 			// CULSTR move Release()s v, d'tor not needed
 			pCS->IsValid();		// message if malformed
 #if defined( TRAPMUNGEDWFNAME)
+			// trap re issue #619
 			if (!WFX2(strtprintf("exPile store '%s'", AsCULSTR(&v).CStr())))
 				throw 99;
 #endif

--- a/src/pp.cpp
+++ b/src/pp.cpp
@@ -492,22 +492,6 @@ bool ppFindFile( 		// find file using paths specified with ppAddPaths. Issues no
 	return ppPath.find( fname, fullPath);
 }						// ppFindFile
 //==========================================================================
-#if 0
-bool ppFindFile( 	// find file using paths specified with ppAddPaths. Issues no message.
-	char* &fname)	//  file to find
-					//    returned updated to full path iff found
-// returns TRUE iff found
-{
-	char fullPath[CSE_MAX_PATH];
-	BOO bFound = ppPath.find( fname, fullPath);
-	if (bFound && _stricmp( fname, fullPath))		// if found path different (else don't save for less fragmentation)
-	{	cupfree( DMPP( fname));		// if not a pointer to "text" embedded in pseudocode, dmfree name
-		fname = strsave( fullPath);		// replace name with full pathname
-	}
-	return bFound;
-}						// ppFindFile
-#endif
-//==========================================================================
 bool ppFindFile( 	// find file using paths specified with ppAddPaths. Issues no message.
 	CULSTR& fname)	//  file to find
 	//    returned updated to full path iff found

--- a/src/pp.h
+++ b/src/pp.h
@@ -19,9 +19,6 @@ bool ppClargIf( const char* s, RC& rc);
 void FC ppClean( CLEANCASE cs);				// init/cleanup
 void ppAddPath( const char* paths);			// add path(s) to search for input/include files
 bool ppFindFile( const char *fname, char *fullPath);	// search pp paths, return full file path
-#if 0
-bool ppFindFile( char* &fname);	// ditto, update fname to path found
-#endif
 bool ppFindFile(CULSTR& fname);	// ditto, update fname to path found
 RC FC ppOpen( const char* fname, const char* defex);		// open file
 void FC ppClose();						// close file(s)

--- a/src/strpak.cpp
+++ b/src/strpak.cpp
@@ -205,8 +205,8 @@ void CULSTR::us_Alloc()		// allocate
 	}
 	else
 	{	// no free slot, enlarge vector
-		if (us_csc.us_vectCULSTREL.size() == 0)
-			us_csc.us_vectCULSTREL.emplace_back("");
+		//  [0] always allocated for null CULSTR
+		assert(us_csc.us_vectCULSTREL.size() >= 1);
 		us_csc.us_vectCULSTREL.emplace_back();
 		us_hCulStr = HCULSTR( us_csc.us_vectCULSTREL.size()) - 1;
 	}

--- a/src/strpak.cpp
+++ b/src/strpak.cpp
@@ -92,27 +92,24 @@ char* CULSTREL::usl_Set(		// set CULSTR
 
 CULSTRCONTAINER::CULSTRCONTAINER() : us_freeChainHead{ 0 }
 {
-	us_vectCULSTREL.push_back("");
+	us_vectCULSTREL.push_back("");	// [0] is always empty string
 }
-
-
-/*static */  CULSTRCONTAINER CULSTR::us_csc;
-
-
-
 //-----------------------------------------------------------------------------
-CULSTR::CULSTR() : us_hCulStr(0) {}
+CULSTRCONTAINER::~CULSTRCONTAINER()
+{ }
 //-----------------------------------------------------------------------------
-CULSTR::CULSTR(const CULSTR& culStr) : us_hCulStr( 0)
+bool CULSTRCONTAINER::us_IsAllocated() const
+{ return us_vectCULSTREL.size() > 0; }
+//=============================================================================
+/*static */  CULSTRCONTAINER CULSTR::us_csc;	// container for pointers to strings
+//=============================================================================
+CULSTR& CULSTR::operator=(CULSTR&& src) noexcept	// move assignment
 {
-	Set(culStr.CStr());
-}
-//-----------------------------------------------------------------------------
-CULSTR::CULSTR(const char* str) : us_hCulStr( 0)
-{
-	Set(str);
-
-}
+	Release();
+	us_hCulStr = src.us_hCulStr;
+	src.us_hCulStr = 0;
+	return *this;
+}	// CULSTR operator= (move)
 //-----------------------------------------------------------------------------
 char* CULSTR::CStrModifiable() const	// pointer to string
 // CAUTION non-const; generally should use CStr()
@@ -136,13 +133,11 @@ void CULSTR::Set(			// set from const char*
 						// if nullptr, release
 {
 	if (!str)
-	{
-		Release();
+	{	Release();
 		// us_hCulStr = 0 in us_Release
 	}
 	else
-	{
-		if (!us_HasCULSTREL())
+	{	if (!us_HasCULSTREL())
 		{	// this CULSTR does not have an allocated slot
 			if (us_AllocMightMove())
 				str = strtmp(str);		// str may be pointing into string vector
@@ -209,7 +204,10 @@ void CULSTR::us_Alloc()		// allocate
 void CULSTR::Release()		// release string
 // revert CULSTR to empty state
 {
-	if (us_hCulStr != 0 && !IsNANDLE())
+// issue: destruction order of static objects indeternimate
+// us_IsAllocated() ensures static container still exists
+	if (us_hCulStr != 0 && !IsNANDLE()
+	 && us_csc.us_IsAllocated())
 	{	CULSTREL& el = us_GetCULSTREL();
 
 		// string pointer: do not free (memory will be reused)

--- a/src/strpak.cpp
+++ b/src/strpak.cpp
@@ -34,10 +34,10 @@ static int TmpstrNx = 0;	// Next available byte in Tmpstr[].
 // == CULSTR ==
 // Persistent string type that can be manipulated in the CUL realm.
 //    (e.g. user input data and expressions, probes etc.)
-//    Implemented as indicies into a vector of std::string.
+//    Implemented as indicies into a vector that points to string in heap.
 //    Important motivation is 4-byte size (same as float and NANDLE).
 //    Cannot use char * due to 8-byte size on 64 bit.
-
+//--------------------------------------------------------------------
 // CULSTREL: one element in vector of strings
 //   = string in dynamic memory plus integer that chains free elements.
 struct CULSTREL
@@ -69,7 +69,7 @@ struct CULSTREL
 		usl_status = uslEMPTY;
 	}
 
-	char* usl_str;				// string data
+	char* usl_str;				// string data (generally in DM heap)
 	int usl_status;				// uslEMPTY: empty (usl_str may or may not be nullptr)
 								// uslDM: in use, usl_str points to heap
 								// uslOTHER: in use, usl_str points elsewhere (do not dmfree)
@@ -89,19 +89,24 @@ char* CULSTREL::usl_Set(		// set CULSTR
 	return strcpy(usl_str, s);
 }	// CULSTREL::usl_Set
 //=============================================================================
-
-CULSTRCONTAINER::CULSTRCONTAINER() : us_freeChainHead{ 0 }
+// container for strings = vector of CULSTREL (char * to text + management)
+struct CULSTRCONTAINER
 {
-	us_vectCULSTREL.push_back("");	// [0] is always empty string
-}
-//-----------------------------------------------------------------------------
-CULSTRCONTAINER::~CULSTRCONTAINER()
-{ }
-//-----------------------------------------------------------------------------
-bool CULSTRCONTAINER::us_IsAllocated() const
-{ return us_vectCULSTREL.size() > 0; }
+	CULSTRCONTAINER() : us_freeChainHead{ 0 }
+	{	us_vectCULSTREL.push_back("");	// [0] is always empty string
+	}
+	~CULSTRCONTAINER() {}
+	std::vector<struct CULSTREL> us_vectCULSTREL;	// vector of string elements
+	// [ 0] always "" (see c'tor)
+	HCULSTR us_freeChainHead;		// 1st free element (0 = none)
+	bool us_IsAllocated() const
+	{   return us_vectCULSTREL.size() > 0;
+	}
+};	// struct CULSTRCONTAINER
 //=============================================================================
-/*static */  CULSTRCONTAINER CULSTR::us_csc;	// container for pointers to strings
+static CULSTRCONTAINER us_csc;	// container for pointers to strings
+								// could be static mbr of CULSTR
+								//   but the requires exposing defns in strpak.h
 //=============================================================================
 CULSTR& CULSTR::operator=(CULSTR&& src) noexcept	// move assignment
 {
@@ -139,8 +144,14 @@ void CULSTR::Set(			// set from const char*
 	else
 	{	if (!us_HasCULSTREL())
 		{	// this CULSTR does not have an allocated slot
-			if (us_AllocMightMove())
-				str = strtmp(str);		// str may be pointing into string vector
+#if 0
+0 str move not possible with current implementation, 5-26
+0 strings are in fixed heap locations
+0 Save for possible future use
+0
+0			if (us_AllocMightMove())
+0				str = strtmp(str);		// str may be pointing into string vector
+#endif
 			us_Alloc();					// can move!
 		}
 
@@ -222,12 +233,16 @@ void CULSTR::Release()		// release string
 
 }	// CULSTR::Release
 //-----------------------------------------------------------------------------
-bool CULSTR::us_AllocMightMove() const	// check if reallocation is possible
-// returns true iff next us_Alloc might trigger us_vectCULSTR reallocation
-{
-	return us_csc.us_freeChainHead == 0
-		&& us_csc.us_vectCULSTREL.size() == us_csc.us_vectCULSTREL.capacity();
-}		// CULSTR::us_AllocMightMove
+#if 0	// 5-26
+0 In current implementation, vector reallocation does move strings in heap
+0 Save re possible implementation change
+0 bool CULSTR::us_AllocMightMove() const	// check if reallocation is possible
+0 // returns true iff next us_Alloc might trigger us_vectCULSTR reallocation
+0 {
+0	return us_csc.us_freeChainHead == 0
+0		&& us_csc.us_vectCULSTREL.size() == us_csc.us_vectCULSTREL.capacity();
+0 }		// CULSTR::us_AllocMightMove
+#endif
 ///////////////////////////////////////////////////////////////////////////////
 
 //-----------------------------------------------------------------------------

--- a/src/strpak.h
+++ b/src/strpak.h
@@ -191,9 +191,9 @@ private:
 							//  = idx into CULSTRCONTAINER.us_vectCULSTREL
 
 public:
-	CULSTR::CULSTR() : us_hCulStr(0)
+	CULSTR() : us_hCulStr(0)
 	{ }
-	CULSTR::CULSTR(const char* str) : us_hCulStr(0)
+	CULSTR(const char* str) : us_hCulStr(0)
 	{	Set(str);	}
 	CULSTR(const CULSTR& culStr) : us_hCulStr(0)
 	{	Set(culStr);	}

--- a/src/strpak.h
+++ b/src/strpak.h
@@ -177,26 +177,36 @@ using HCULSTR = uint32_t;	// CULSTR handle: 32 bit index into CULSTRCONTAINER::u
 struct CULSTRCONTAINER
 {
 	CULSTRCONTAINER();
+	~CULSTRCONTAINER();
 	std::vector<struct CULSTREL> us_vectCULSTREL;	// vector of string elements
 													// [ 0] always "" (see c'tor)
 	HCULSTR us_freeChainHead;		// 1st free element (0 = none)
+	bool us_IsAllocated() const;
 };	// struct CULSTRCONTAINER
 
 struct CULSTR
 {
-	CULSTR();
-	CULSTR(const CULSTR& culStr);
-	CULSTR(const char* s);
-	~CULSTR() { Set(nullptr); };
+private:
+	HCULSTR us_hCulStr;		// 4 byte handle for this CULSTR
+							//  = idx into CULSTRCONTAINER.us_vectCULSTREL
 
-	HCULSTR us_hCulStr;
-
+public:
+	CULSTR::CULSTR() : us_hCulStr(0)
+	{ }
+	CULSTR::CULSTR(const char* str) : us_hCulStr(0)
+	{	Set(str);	}
+	CULSTR(const CULSTR& culStr) : us_hCulStr(0)
+	{	Set(culStr);	}
+	~CULSTR()
+	{	Release();	};
 	operator char* () = delete;  // not modifiable via pointer
 	operator const char* () { return CStr(); }
 	operator const char* () const { return CStr(); }
 	CULSTR& operator =(const char* s) { Set(s); return *this; }
 	CULSTR& operator =(const std::string& s) { Set(s); return *this; }
 	CULSTR& operator =(const CULSTR& s) { Set(s); return *this; }
+	CULSTR& operator =(CULSTR&& s) noexcept;
+
 	char* CStrModifiable() const;
 	const char* CStr() const { return CStrModifiable(); }
 	const char* CStrIfSet(const char* sDflt) const
@@ -223,6 +233,10 @@ struct CULSTR
 		const char* s = CStr();
 		return s == nullptr || *s == '\0';
 	}
+
+	// Getter / Setter for unit test
+	HCULSTR GetHandle() const { return us_hCulStr; }
+	void SetHandle(HCULSTR h) { us_hCulStr = h; }
 
 private:
 	static CULSTRCONTAINER us_csc;

--- a/src/strpak.h
+++ b/src/strpak.h
@@ -169,20 +169,13 @@ char* _strlwr(char* stringMod);
 
 // == CULSTR ==
 // Persistent string type that can be manipulated in the CUL realm.
+//    (e.g. user input data and expressions, probes etc.)
+//    Implemented as indicies into vector that points to strings in heap.
+//    Important motivation is 4-byte size (same as float and NANDLE).
+//    Cannot use char * due to 8-byte size on 64 bit.
 
 using HCULSTR = uint32_t;	// CULSTR handle: 32 bit index into CULSTRCONTAINER::us_vectCULSTREL
 							//   same size as NANDLE re support of string expressions
-
-// container for strings = vector of CULSTREL (char * to text + management)
-struct CULSTRCONTAINER
-{
-	CULSTRCONTAINER();
-	~CULSTRCONTAINER();
-	std::vector<struct CULSTREL> us_vectCULSTREL;	// vector of string elements
-													// [ 0] always "" (see c'tor)
-	HCULSTR us_freeChainHead;		// 1st free element (0 = none)
-	bool us_IsAllocated() const;
-};	// struct CULSTRCONTAINER
 
 struct CULSTR
 {
@@ -219,8 +212,6 @@ public:
 	void Set(const std::string& s) { Set(s.c_str()); }
 	void Set(const CULSTR& cs) { Set(cs.CStr()); }
 
-	char* Strsave() const { return strsave(CStr()); }
-
 	void Release();
 	void FixAfterCopy();
 
@@ -229,34 +220,31 @@ public:
 	bool IsNull() const { return us_hCulStr == 0; }
 	bool IsSet() const { return us_hCulStr != 0; }
 	bool IsBlank() const
-	{
-		const char* s = CStr();
+	{	const char* s = CStr();
 		return s == nullptr || *s == '\0';
 	}
 
 	// Getter / Setter for unit test
+	//  NOT for general use!
 	HCULSTR GetHandle() const { return us_hCulStr; }
 	void SetHandle(HCULSTR h) { us_hCulStr = h; }
 
 private:
-	static CULSTRCONTAINER us_csc;
-#if 0
-	static std::vector<struct CULSTREL> us_vectCULSTREL;
-	static HCULSTR us_freeChainHead;
-#endif
-
 	void us_Alloc();
-	bool us_AllocMightMove() const;
-	CULSTREL& us_GetCULSTREL() const;
+#if 0
+0 Not needed, 5-26.  See strpak.cpp
+0	bool us_AllocMightMove() const;
+#endif
+	struct CULSTREL& us_GetCULSTREL() const;
 	bool us_HasCULSTREL() const;
 
 };	// struct CULSTR
-
+//-----------------------------------------------------------------------------
 inline CULSTR& AsCULSTR(void* p)
 {
 	return *(reinterpret_cast<CULSTR*>(p));
 }	// ::AsCULSTR
-//-------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 inline const CULSTR& AsCULSTR(const void* p)
 {
 	return *(reinterpret_cast<const CULSTR*>(p));

--- a/src/vecpak.h
+++ b/src/vecpak.h
@@ -497,7 +497,7 @@ template< typename T> class VMovingSum
 	size_t iNew;	// idx of newest value in vals[]
 	size_t nCur;	// # of vals[] currently set
 public:
-	VMovingSum(size_t _nSiz = 0) : vals(nullptr), nSiz(0), vSum(0), iOld(0), nCur(0)
+	VMovingSum(size_t _nSiz = 0) : vals(nullptr), nSiz(0), vSum(0), iOld(0), iNew(0), nCur(0)
 	{	if (_nSiz > 0)
 			vm_Init(_nSiz);
 	}

--- a/src/wfpak.cpp
+++ b/src/wfpak.cpp
@@ -795,7 +795,7 @@ void WDYEAR::wdy_Stats(			// statistics for day
 									//   [ 1] = ditto, next highest
 // returns min, mean, and max dry-bulb for day
 {
-	VHR tdvElecHr[ 24];		// day's tdvElec for hour-rank sort
+	VHR tdvElecHr[24] = { 0 };		// day's tdvElec for hour-rank sort
 	taDbMin = 9999.;
 	taDbMax = tdvElecPk = -9999.;
 	taDbAvg = tdvElecAvg = 0.;

--- a/src/xiopak.cpp
+++ b/src/xiopak.cpp
@@ -583,6 +583,7 @@ int xfWriteable(			// check whether file is writeable
 ////////////////////////////////////////////////////////////////////////
 #if 0
 // idea: validate path re syntactical correctness
+// see issue #629
 bool xfIsValidPathSyntax(
 	const char* fPath)
 {

--- a/src/xiopak.cpp
+++ b/src/xiopak.cpp
@@ -577,11 +577,25 @@ int xfWriteable(			// check whether file is writeable
 	return ret;
 }	// xfWriteable
 ////////////////////////////////////////////////////////////////////////
-// path notes, 4-2016
+// Pre- std::filesystem notes (4-2016)
 //   Windows extended paths \\?\ not supported
 //   Only \ separator is supported (not /)
-//   consider stdlib filesystem, Boost filesystem, or POCO for more generality
 ////////////////////////////////////////////////////////////////////////
+#if 0
+// idea: validate path re syntactical correctness
+bool xfIsValidPathSyntax(
+	const char* fPath)
+{
+	// 1st try -- just use xfExist
+	//   Does not return -1 for at least some bad paths
+	//   TODO: debug/refine xfExist
+	int xfExistRet = xfExist(fPath);
+
+	return xfExistRet >= 0;
+
+}	// xfIsValidPathSyntax
+#endif
+//------------------------------------------------------------------------
 int xfExist(	// determine file existence
 	const char* fPath,				// pathname
 	char* fPathChecked /*=NULL*/)	// ptr to optional buf[ CSE_MAX_PATH]
@@ -633,7 +647,7 @@ int fileFind1(			// check existence of a single file
 	int i = 0;
 	if (drvDir && drvDir[ 0])
 	{  	strTrim( tPath, drvDir);
-		i = static_cast<int>(strlen(tPath));
+		i = strlenInt(tPath);
 		if (tPath[ i-1] != ':' && tPath[ i-1] != '\\')
 			tPath[ i++] = '\\';		// add \ to dir if needed
 	}
@@ -654,7 +668,7 @@ bool findFile( 	// non-member function to find file on given path
 {
 	buf[ 0] = '\0';
 	if (!fName)
-		return FALSE;					// insurance: NULL pathname ptr is never found
+		return false;					// insurance: NULL pathname ptr is never found
 
 	char fNameFound[ CSE_MAX_PATH];		// Holds a fullpath
 	// lookup name as provided (no path)

--- a/test/unit/strpak.unit.cpp
+++ b/test/unit/strpak.unit.cpp
@@ -96,7 +96,6 @@ TEST(strpak, find_and_replace_functions) {
 	}
 }
 
-#if 1
 TEST(strpak, CULSTR_funtions) {
 	
 	CULSTR us1;
@@ -118,17 +117,25 @@ TEST(strpak, CULSTR_funtions) {
 
 	us2.Set(nullptr);
 	CULSTR us4("Here is another string that should go in slot 2");
-	EXPECT_EQ(us4.us_hCulStr, 2);
+	EXPECT_EQ(us4.GetHandle(), 2);
 
 	EXPECT_STREQ((const char*)us1, sTest);
 
 	CULSTR us5;
-	us5.us_hCulStr = us3.us_hCulStr;
+	HCULSTR h3 = us3.GetHandle();
+	us5.SetHandle(h3);
 	us5.FixAfterCopy();
 	EXPECT_STREQ(us3.CStr(), sTest);
 	EXPECT_STREQ(us5.CStr(), sTest);
-	EXPECT_NE(us3.us_hCulStr, us5.us_hCulStr);
+	EXPECT_NE(h3, us5.GetHandle());
+
+	const char* s3 = "Hello 3";
+	us3 = s3;
+	us5 = std::move(us3);
+	EXPECT_STREQ(us5.CStr(), s3);
+	EXPECT_EQ(us5.GetHandle(), h3);
+	EXPECT_TRUE(us3.IsNull());
+	EXPECT_FALSE(us5.IsBlank());
 
 }
-#endif
 


### PR DESCRIPTION
## Description

Fixes issue #619.

Origin of error = incorrect CULSTR assignment sequence in cuparse.cpp exOrk().

The incorrect logic was located with a hardcoded trap that detected bad tp_wfName.  A sequence of test files were run in a loop using the 64 bit release until the error manifested (usually within 5 minutes).  With the fix, the test loop has been run for several hours without error.

The reason that the problem rarely occurred has not been figured out.  The problem case was never duplicated while debugging, so detailed research was not possible.  Something to do with operating system memory management timing (CULSTR uses the heap for string storage) (?).

Also did some cleanup, especially in CULSTR (strpak.cpp).  Added CULSTR move assignment operator.

No results changes.

No documentation changes.