### PR TITLE
Migrate vendor submodule handling to atheneum-forge's add_submodule macro

### DIFF
--- a/cmake/initialize-submodules.cmake
+++ b/cmake/initialize-submodules.cmake
@@ -1,87 +1,73 @@
-macro(initialize_submodules)
-  if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
-    # Initialize submodules
-    set(git_modules_file "${PROJECT_SOURCE_DIR}/.gitmodules")
-    if (EXISTS ${git_modules_file})
-      file(STRINGS ${git_modules_file} file_lines)
-      foreach(line ${file_lines})
-        if (${line} MATCHES "url =")
-          string(REGEX REPLACE "\\s*url = .*/(.*).git" "\\1" submodule "${line}")
-          string(STRIP "${submodule}" submodule)
-          if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${submodule}")
-            message(FATAL_ERROR "Submodule directory \"${CMAKE_CURRENT_SOURCE_DIR}/${submodule}\" does not exist")
-          endif()
-          # Initialize submodule if it hasn't already been cloned
-          if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${submodule}/.git")
-            message(STATUS "Initialize ${submodule} submodule")
-            execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive "${CMAKE_CURRENT_SOURCE_DIR}/${submodule}"
-              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-              RESULT_VARIABLE GIT_SUBMOD_RESULT)
-            if(NOT GIT_SUBMOD_RESULT EQUAL "0")
-              message(FATAL_ERROR "git submodule update --init --recursive ${CMAKE_CURRENT_SOURCE_DIR}/${submodule} failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
-            endif()
-          endif()
-        endif()
-      endforeach()
-    endif()
+# SPDX-FileCopyrightText: © 2025 Big Ladder Software <info@bigladdersoftware.com>
+# SPDX-License-Identifier: BSD-3-Clause
 
-    # Create git hooks
-    option(CREATE_GIT_HOOKS "Create git hooks to automatically update submodules." ON)
-    if (CREATE_GIT_HOOKS)
-      # post-checkout
-      if (NOT EXISTS "${PROJECT_SOURCE_DIR}/.git/hooks/post-checkout")
-        file(WRITE "${PROJECT_SOURCE_DIR}/.git/hooks/post-checkout"
-"#!/bin/sh
+macro(add_submodule submodule_name)
+    # Clone a submodule and add its subdirectory to the build (if the corresponding target hasn't already been added)
+    set(options) # None
+    set(one_value_args
+            TARGET_NAME           # Specify if target name is different from the submodule name
+            PARENT_SUBMODULE_PATH # Specify if you want to leverage a submodule outside of this project's vendor directory
+    )
+    set(multi_value_args
+            CACHE_ON # Set options from submodule as "ON" in the cache
+            CACHE_OFF # Set options from submodule as "OFF" in the cache
+            MARK_AS_ADVANCED # Mark certain options from the submodule project as advanced (to hide from higher level CMake GUI)
+    )
+    cmake_parse_arguments(add_${submodule_name}_args "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
 
-echo \"Running .git/hooks/post-checkout\"
-echo
+    if (DEFINED add_${submodule_name}_args_TARGET_NAME)
+        set(target_name ${add_${submodule_name}_args_TARGET_NAME})
+    else ()
+        set(target_name "${submodule_name}")
+    endif ()
 
-echo \"git submodule sync --recursive\"
-echo
-git submodule sync --recursive
+    if (DEFINED add_${submodule_name}_args_PARENT_SUBMODULE_PATH)
+        set(submodule_path "${add_${submodule_name}_args_PARENT_SUBMODULE_PATH}/vendor/${submodule_name}")
+    else ()
+        set(submodule_path "${CMAKE_CURRENT_SOURCE_DIR}/${submodule_name}")
+    endif ()
 
-echo \"git submodule update --init --recursive\"
-git submodule update --init --recursive
+    # Clone repository
+    if (GIT_FOUND AND NOT EXISTS "${submodule_path}/.git")
+        message(STATUS "Cloning submodule \"${submodule_name}\"")
+        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init ${submodule_path}
+                WORKING_DIRECTORY ${submodule_path}
+                RESULT_VARIABLE GIT_SUBMOD_RESULT)
+        if (NOT GIT_SUBMOD_RESULT EQUAL "0")
+            message(FATAL_ERROR "Unable to update submodule \"${submodule_name}\"")
+        endif ()
+    endif ()
 
-"        
-        )
-      endif()
-      # post-merge
-      if (NOT EXISTS "${PROJECT_SOURCE_DIR}/.git/hooks/post-merge")
-        file(WRITE "${PROJECT_SOURCE_DIR}/.git/hooks/post-merge"
-"#!/bin/sh
+    # Cache on -- must run before add_subdirectory: these are typically options the
+    # submodule's own CMakeLists.txt reads via option()/if() to decide what to build,
+    # so forcing them after add_subdirectory would be too late to have any effect.
+    if (DEFINED add_${submodule_name}_args_CACHE_ON)
+        foreach (variable ${add_${submodule_name}_args_CACHE_ON})
+            set(${variable} ON CACHE BOOL "" FORCE)
+        endforeach ()
+    endif ()
 
-# Note: Merge also happens after pull command.
-echo \"Running .git/hooks/post-merge\"
-echo
+    # Cache off -- see Cache on above
+    if (DEFINED add_${submodule_name}_args_CACHE_OFF)
+        foreach (variable ${add_${submodule_name}_args_CACHE_OFF})
+            set(${variable} OFF CACHE BOOL "" FORCE)
+        endforeach ()
+    endif ()
 
-echo \"git submodule sync --recursive\"
-echo
-git submodule sync --recursive
+    # Add subdirectory
+    if (NOT TARGET ${target_name})
+        if (NOT EXISTS "${submodule_path}")
+            message(FATAL_ERROR "Submodule directory \"${submodule_path}\" does not exist")
+        endif ()
+        add_subdirectory(${submodule_path})
+    endif ()
 
-echo \"git submodule update --init --recursive\"
-git submodule update --init --recursive
+    # Mark as advanced -- runs after add_subdirectory since some of these variables are
+    # only declared (as cache entries) by the submodule's own CMakeLists.txt
+    if (DEFINED add_${submodule_name}_args_MARK_AS_ADVANCED)
+        foreach (variable ${add_${submodule_name}_args_MARK_AS_ADVANCED})
+            mark_as_advanced(${variable})
+        endforeach ()
+    endif ()
 
-"        
-        )
-      endif()
-      # pre-push
-      if (NOT EXISTS "${PROJECT_SOURCE_DIR}/.git/hooks/pre-push")
-        file(WRITE "${PROJECT_SOURCE_DIR}/.git/hooks/pre-push"
-"#!/bin/sh
-
-echo \"Running .git/hooks/pre-push\"
-
-# Check if any submodules have unpushed commits.
-if ! [[ -z $(git submodule --quiet foreach --recursive 'git log --branches --not --remotes') ]]; then
-  echo
-  echo \"Warning: You have unpushed commits in one or more submodules. Don't forget to\"
-  echo \"push them if the parent repository is expecting those changes.\"
-fi
-
-"        
-        )
-      endif()
-    endif()
-  endif()
 endmacro()

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -1,68 +1,82 @@
 include(initialize-submodules)
-initialize_submodules()
+
+# Googletest -- added first, before any submodule that might vendor its own copy of
+# add_submodule() and shadow this one. CMake macros are global, not scoped to the
+# directory that defines them, so a same-named macro loaded later (e.g. HPWHsim's own)
+# would silently replace this one for any add_submodule() call below that point. Adding
+# it here first, with our preferred settings, also means the add_subdirectory'd projects
+# below that check `if (NOT TARGET gtest)` themselves correctly see it as already provided.
+if (NOT TARGET gtest)
+  # Prevent GoogleTest from overriding our compiler/linker options
+  # when building with Visual Studio
+  add_submodule(googletest TARGET_NAME gtest
+    CACHE_ON gtest_force_shared_crt BUILD_GTEST BUILD_GMOCK
+    CACHE_OFF INSTALL_GTEST
+    MARK_AS_ADVANCED BUILD_GTEST BUILD_GMOCK INSTALL_GTEST
+  )
+  set_target_properties(gtest PROPERTIES FOLDER Dependencies/Test)
+  set_target_properties(gmock PROPERTIES FOLDER Dependencies/Test)
+  set_target_properties(gtest_main PROPERTIES FOLDER Dependencies/Test)
+  set_target_properties(gmock_main PROPERTIES FOLDER Dependencies/Test)
+endif ()
 
 # Penumbra
-add_subdirectory(penumbra)
+add_submodule(penumbra
+  MARK_AS_ADVANCED
+    BUILD_PENUMBRA_TESTING
+    PENUMBRA_COVERAGE
+    PENUMBRA_STATIC_LIB
+    # Should be marked in future Penumbra update
+    GLFW_BUILD_DOCS
+    GLFW_BUILD_EXAMPLES
+    GLFW_BUILD_TESTS
+    GLFW_DOCUMENT_INTERNALS
+    GLFW_INSTALL
+    GLFW_USE_HYBRID_HPG
+    GLFW_VULKAN_STATIC
+    LIB_SUFFIX
+    USE_MSVC_RUNTIME_LIBRARY_DLL
+)
 
 set_target_properties(glfw PROPERTIES FOLDER Dependencies/Penumbra/GLFW)
 set_target_properties(glad PROPERTIES FOLDER Dependencies/Penumbra)
 set_target_properties(penumbra PROPERTIES FOLDER Dependencies/Penumbra)
 set_target_properties(tess2 PROPERTIES FOLDER Dependencies/Penumbra)
 
-mark_as_advanced(
-  BUILD_PENUMBRA_TESTING
-  PENUMBRA_COVERAGE
-  PENUMBRA_STATIC_LIB
-  # Should be marked in future Penumbra update
-  GLFW_BUILD_DOCS
-  GLFW_BUILD_EXAMPLES
-  GLFW_BUILD_TESTS
-  GLFW_DOCUMENT_INTERNALS
-  GLFW_INSTALL
-  GLFW_USE_HYBRID_HPG
-  GLFW_VULKAN_STATIC
-  LIB_SUFFIX
-  USE_MSVC_RUNTIME_LIBRARY_DLL
-)
-
 # Kiva
-set(KIVA_TESTING OFF CACHE BOOL "" FORCE)
-set(KIVA_EXE_BUILD OFF CACHE BOOL "" FORCE)
-set(KIVA_COVERAGE OFF CACHE BOOL "" FORCE)
-set(KIVA_3D OFF CACHE BOOL "" FORCE)
-set(BUILD_TESTING OFF CACHE BOOL "" FORCE) # Polution from eigen
-
 option( KIVA_GROUND_PLOT "Build ground plotting library" OFF )
 
-add_subdirectory(kiva)
+add_submodule(kiva TARGET_NAME libkiva
+  CACHE_OFF
+    KIVA_TESTING
+    KIVA_EXE_BUILD
+    KIVA_COVERAGE
+    KIVA_3D
+    BUILD_TESTING # Pollution from eigen
+  MARK_AS_ADVANCED
+    KIVA_3D
+    KIVA_EXE_BUILD
+    KIVA_COVERAGE
+    KIVA_GROUND_PLOT
+    KIVA_STATIC_LIB
+    KIVA_TESTING
+    ENABLE_OPENMP
+    # Should be marked in future Kiva update
+    FMT_TEST
+    FMT_CUDA_TEST
+    FMT_DEBUG_POSTFIX
+    FMT_DOC
+    FMT_FUZZ
+    FMT_MODULE
+    FMT_INSTALL
+    FMT_OS
+    FMT_PEDANTIC
+    FMT_WERROR
+    FMT_INC_DIR
+)
 
 set_target_properties(libkiva PROPERTIES FOLDER Dependencies/Kiva)
 set_target_properties(fmt PROPERTIES FOLDER Dependencies/Kiva)
-
-mark_as_advanced(
-  KIVA_3D
-  KIVA_EXE_BUILD
-  KIVA_COVERAGE
-  KIVA_GROUND_PLOT
-  KIVA_STATIC_LIB
-  KIVA_TESTING
-  ENABLE_OPENMP
-)
-
-# Should be marked in future Kiva update
-mark_as_advanced(
-  FMT_TEST
-  FMT_CUDA_TEST
-  FMT_DEBUG_POSTFIX
-  FMT_DOC
-  FMT_FUZZ
-  FMT_MODULE
-  FMT_INSTALL
-  FMT_OS
-  FMT_PEDANTIC
-  FMT_WERROR
-  FMT_INC_DIR
-)
 
 if (KIVA_GROUND_PLOT)
   set_target_properties(groundplot PROPERTIES FOLDER Dependencies/Kiva/GroundPlot)
@@ -74,11 +88,9 @@ endif()
 # HPWHsim
 set(HPWHSIM_OMIT_TESTTOOL ON CACHE BOOL "HPWHsim: Do not build testing code" FORCE)
 set(HPWHSIM_ABRIDGED ON CACHE BOOL "HPWHsim: omit code not used by CSE" FORCE)
-mark_as_advanced(
-  HPWHSIM_OMIT_TESTTOOL
-  HPWHSIM_ABRIDGED
+add_submodule(HPWHsim
+  MARK_AS_ADVANCED HPWHSIM_OMIT_TESTTOOL HPWHSIM_ABRIDGED
 )
-add_subdirectory(HPWHsim)
 
 set_target_properties(HPWHsim PROPERTIES FOLDER Dependencies/HPWHsim)
 if (NOT HPWHSIM_OMIT_TESTTOOL)
@@ -92,19 +104,3 @@ mark_as_advanced(
   BUILD_BTWXT_TESTING
   GIT_SUBMODULE # Should go away with Btwxt update
 )
-
-if (NOT TARGET gtest)
-  # Prevent GoogleTest from overriding our compiler/linker options
-  # when building with Visual Studio
-  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-  set(BUILD_GTEST ON CACHE BOOL "" FORCE MARK)
-  set(BUILD_GMOCK ON CACHE BOOL "" FORCE)
-  set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
-  mark_as_advanced(BUILD_GTEST BUILD_GMOCK INSTALL_GTEST)
-  add_subdirectory(googletest)
-  set_target_properties(gtest PROPERTIES FOLDER Dependencies/Test)
-  set_target_properties(gmock PROPERTIES FOLDER Dependencies/Test)
-  set_target_properties(gtest_main PROPERTIES FOLDER Dependencies/Test)
-  set_target_properties(gmock_main PROPERTIES FOLDER Dependencies/Test)
-endif ()
-


### PR DESCRIPTION
## Description

Replaces cse's homegrown `cmake/initialize-submodules.cmake` (which parsed `.gitmodules` directly and hardcoded git hooks into `.git/hooks/`) with atheneum-forge's canonical `add_submodule()` macro.

Motivation: cse's own script broke CMake configure entirely inside a `git worktree` checkout, since it wrote hooks to `<repo>/.git/hooks/...` -- a path that doesn't exist in a worktree, where `.git` is a file pointing elsewhere. Fixes #667.

Changes:
- `cmake/initialize-submodules.cmake`: replaced with atheneum-forge's `add_submodule()` macro (bigladder/atheneum-forge#46 -- includes a cache-variable dereference fix, a clear missing-directory error, and a `CACHE_ON`/`CACHE_OFF` ordering fix).
- `vendor/CMakeLists.txt`: converted each direct submodule (`penumbra`, `kiva`, `HPWHsim`, `googletest`) from `add_subdirectory()` to `add_submodule()`, consolidating scattered `mark_as_advanced()`/cache-forcing calls into the macro's own arguments where safe to do so (kept HPWHsim's two `set()` calls as-is since they carry custom docstrings the macro's sugar can't preserve).
- Reordered so `googletest` is added first, before any submodule that might vendor its own conflicting `add_submodule` macro. CMake macros are global, not directory-scoped -- HPWHsim vendors an older, positional-argument version of the same macro name, which was silently shadowing atheneum-forge's keyword-argument one for anything called after it.
- Drops the auto-installed git hooks (post-checkout/post-merge/pre-push, which ran `git submodule update --init --recursive` automatically) that cse's old script provided -- contributors now need to run that manually after checkout/pull. Re-adding this properly (worktree-safe) is tracked in atheneum-forge#44.

## Test plan
- [x] Full local build + `ctest` (82/82 passed), both before and after the cache-variable consolidation
- [x] Manually verified the case that motivated this: configuring/building successfully from a `git worktree` checkout

**Note:** depends on bigladder/atheneum-forge#46, currently in draft/under review. `cmake/initialize-submodules.cmake` here is a vendored copy of that fix.