### PR TITLE
Fix output file name case on case-insensitive file systems

### DIFF
--- a/src/xiopak.cpp
+++ b/src/xiopak.cpp
@@ -599,18 +599,13 @@ bool xfIsValidPathSyntax(
 }	// xfIsValidPathSyntax
 #endif
 //------------------------------------------------------------------------
-static bool xfCaseCorrect(	// case-insensitive fallback lookup, in place
-	char* tPath)			// path to check/correct; must be writable and
-							//   large enough (correction never lengthens it)
-// CSE has historically assumed a case-insensitive file system; many input,
-//   weather/TDV, and #include file references use a case that differs from
-//   their on-disk name. If tPath isn't found as given, look for a
-//   case-insensitive match in its directory and correct tPath's file name
-//   portion in place (same length: safe). On a case-insensitive file system
-//   (Windows, default macOS), the exact-case check already succeeds and this
-//   is never reached; on a case-sensitive one (Linux, or macOS with a
-//   case-sensitive volume), it provides the same tolerant behavior.
-// Returns true iff tPath was corrected to an existing, unambiguous case-insensitive match.
+static bool xfCaseCorrect(	// look up tPath's on-disk case; corrects tPath's file name in place
+	char* tPath)			// path to check/correct; must be writable (correction never lengthens it)
+// On case-sensitive systems (Linux) a wrong-case check fails outright, so this runs as a
+//   not-found fallback. On case-insensitive ones (Windows, default macOS) the exact check can
+//   succeed with the wrong case, so callers needing the true on-disk case call this even on success.
+// Returns true if tPath's directory has a matching entry: an exact match wins immediately (never
+//   ambiguous, even with differently-cased siblings); else a single case-insensitive match.
 {
 	filesys::path p( tPath);
 	filesys::path dir = p.has_parent_path() ? p.parent_path() : filesys::path(".");
@@ -631,13 +626,20 @@ static bool xfCaseCorrect(	// case-insensitive fallback lookup, in place
 		return false;
 	}
 	std::vector<std::string> matches;
+	bool exact = false;
 	filesys::directory_iterator end;
 	for (filesys::directory_iterator it( dir, ec); !ec && it != end; it.increment( ec))
 	{	std::string entryName = it->path().filename().string();
+		if (entryName == target)
+		{	exact = true;	// already correct on disk: not ambiguous, regardless of siblings
+			break;
+		}
 		if (std::equal( entryName.begin(), entryName.end(), target.begin(), target.end(),
 				[]( unsigned char a, unsigned char b) { return tolower( a) == tolower( b); }))
 			matches.push_back( entryName);
 	}
+	if (exact)
+		return true;
 	if (isRealError( ec))
 	{	err( ERR, "Error scanning directory '%s' for case-insensitive match to '%s': %s",
 			dir.string().c_str(), target.c_str(), ec.message().c_str());
@@ -715,6 +717,10 @@ int fileFind1(			// check existence of a single file
 
 	int ret = xfExist( tPath, fPath);	// check file
 										// return exact name checked
+	if (ret > 0 && fPath)
+		xfCaseCorrect( fPath);	// verify/correct fPath's case against the on-disk entry: xfExist's
+								//   exact-case check can succeed on a case-insensitive file system
+								//   (e.g. macOS, Windows) even when the given case is wrong
 	return ret;
 }			// fileFind1
 //-----------------------------------------------------------------------------

--- a/test/ref-win32-msvc/1ZATTIC.REP
+++ b/test/ref-win32-msvc/1ZATTIC.REP
@@ -3,13 +3,13 @@
 Error Messages for Run 001:
 
 ---------------
-1zattic.cse(372): Info: 
+1ZAttic.cse(372): Info: 
   zone 'Attic': 'znTH' is ignored when zone is unconditioned
 ---------------
-1zattic.cse(372): Info: 
+1ZAttic.cse(372): Info: 
   zone 'Attic': 'znTC' is ignored when zone is unconditioned
 ---------------
-1zattic.cse(372): Info: 
+1ZAttic.cse(372): Info: 
   zone 'Attic': 'znQMxHRated' is ignored when zone is unconditioned
 ---------------
 Info: Zone 'Z1': Temp control outcomes
@@ -17737,13 +17737,13 @@ Input for Run 001:
         
          $EOF
 -----------------------
-???     1zattic.cse(372): Info: 
+???     1ZAttic.cse(372): Info: 
 ???       zone 'Attic': 'znTH' is ignored when zone is unconditioned
 -----------------------
-???     1zattic.cse(372): Info: 
+???     1ZAttic.cse(372): Info: 
 ???       zone 'Attic': 'znTC' is ignored when zone is unconditioned
 -----------------------
-???     1zattic.cse(372): Info: 
+???     1ZAttic.cse(372): Info: 
 ???       zone 'Attic': 'znQMxHRated' is ignored when zone is unconditioned
 -----------------------
 

--- a/test/ref-win32-msvc/dhw02.rep
+++ b/test/ref-win32-msvc/dhw02.rep
@@ -3,7 +3,7 @@
 Error Messages for Run 001:
 
 ---------------
-dhw02.cse(38): Info: 
+DHW02.cse(38): Info: 
   DHWSYS 'DS0': 'wsDayWasteVol' is ignored -- there are no wsDayUse draws.
 ---------------
 
@@ -81,10 +81,10 @@ Input for Run 001:
 Error Messages for Run 002:
 
 ---------------
-dhw02.cse(38): Info: 
+DHW02.cse(38): Info: 
   DHWSYS 'DS0': 'wsDayWasteVol' is ignored -- there are no wsDayUse draws.
 ---------------
-dhw02.cse(121): Info: DHWSYS 'DS2': 
+DHW02.cse(121): Info: DHWSYS 'DS2': 
     'wsDayWasteBranchVolF' is ignored -- there are no wsDayUse draws.
 ---------------
 
@@ -1111,7 +1111,7 @@ Input for Run 001:
         
         METER Elec1
 -----------------------
-???     dhw02.cse(38): Info: 
+???     DHW02.cse(38): Info: 
 ???       DHWSYS 'DS0': 'wsDayWasteVol' is ignored -- there are no wsDayUse draws.
 -----------------------
         METER Fuel1
@@ -1347,10 +1347,10 @@ Input for Run 001:
         
         
 -----------------------
-???     dhw02.cse(38): Info: 
+???     DHW02.cse(38): Info: 
 ???       DHWSYS 'DS0': 'wsDayWasteVol' is ignored -- there are no wsDayUse draws.
 -----------------------
-???     dhw02.cse(121): Info: DHWSYS 'DS2': 
+???     DHW02.cse(121): Info: DHWSYS 'DS2': 
 ???         'wsDayWasteBranchVolF' is ignored -- there are no wsDayUse draws.
 -----------------------
 


### PR DESCRIPTION
## Description

The documented contract (`ucFileName` in top-members.md) says default output file names take the case of the input file *as resolved on disk*, which may differ from the case typed on the command line -- e.g. input file `1ZAttic.cse`, invoked as `cse 1zattic`, should produce `1ZAttic.rep`, not `1zattic.rep`. This held on Linux (case-sensitive) but was broken on macOS/Windows (case-insensitive, case-preserving).

Root cause: `xfExist` (xiopak.cpp) only invoked the case-insensitive fallback (`xfCaseCorrect`) when the exact-case existence check failed outright. On a case-sensitive filesystem, a wrong-case lookup does fail, so the fallback correctly resolves and rewrites to the true on-disk case. On a case-insensitive filesystem, the exact-case check *succeeds* even with the wrong case -- the OS resolves it silently -- so the fallback never ran, and the wrong case flowed straight through into `InputFilePath`/`InputFilePathNoExt`, and from there into every default output file name.

Fix:
- `xfCaseCorrect` now short-circuits on a literal exact match found during its directory scan, before considering case-insensitive matches -- making it safe to call even when the exact-case check already "succeeded," without ever risking its existing ambiguous-match error against genuine case-variant siblings on a case-sensitive filesystem.
- `fileFind1` (used by `findFile`, which resolves the input file, `#include` files, and the weather file) now calls `xfCaseCorrect` after a successful check too, not just as a not-found fallback -- this is what actually closes the gap.
- Scope is deliberately narrow: the general-purpose `xfExist()` (used by the `fileExists()` input-expression function and report-file existence pre-checks) is untouched, so no extra directory-scan overhead is added to what could be a per-timestep expression evaluation.

## Test plan
- [x] Full local build + `ctest` (82/82 passed)
- [x] Manually confirmed zero output-filename casing mismatches across the whole test suite (previously ~30 cases where output case followed the ctest-invocation case instead of the actual input file's on-disk case)